### PR TITLE
feat: add mocks from rbmk-project/dnscore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rbmk-project/common
 
 go 1.23.3
+
+require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/mocks/conn.go
+++ b/mocks/conn.go
@@ -1,0 +1,81 @@
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Adapted from: https://github.com/ooni/probe-cli/blob/v3.20.1/internal/mocks/dialer.go
+//
+
+package mocks
+
+import (
+	"net"
+	"time"
+)
+
+// Conn is a mockable [net.Conn].
+type Conn struct {
+	// MockRead is the function to call when Read is called.
+	MockRead func(b []byte) (int, error)
+
+	// MockWrite is the function to call when Write is called.
+	MockWrite func(b []byte) (int, error)
+
+	// MockClose is the function to call when Close is called.
+	MockClose func() error
+
+	// MockLocalAddr is the function to call when LocalAddr is called.
+	MockLocalAddr func() net.Addr
+
+	// MockRemoteAddr is the function to call when RemoteAddr is called.
+	MockRemoteAddr func() net.Addr
+
+	// MockSetDeadline is the function to call when SetDeadline is called.
+	MockSetDeadline func(t time.Time) error
+
+	// MockSetReadDeadline is the function to call when SetReadDeadline is called.
+	MockSetReadDeadline func(t time.Time) error
+
+	// MockSetWriteDeadline is the function to call when SetWriteDeadline is called.
+	MockSetWriteDeadline func(t time.Time) error
+}
+
+var _ net.Conn = &Conn{}
+
+// Read calls MockRead.
+func (c *Conn) Read(b []byte) (int, error) {
+	return c.MockRead(b)
+}
+
+// Write calls MockWrite.
+func (c *Conn) Write(b []byte) (int, error) {
+	return c.MockWrite(b)
+}
+
+// Close calls MockClose.
+func (c *Conn) Close() error {
+	return c.MockClose()
+}
+
+// LocalAddr calls MockLocalAddr.
+func (c *Conn) LocalAddr() net.Addr {
+	return c.MockLocalAddr()
+}
+
+// RemoteAddr calls MockRemoteAddr.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.MockRemoteAddr()
+}
+
+// SetDeadline calls MockSetDeadline.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.MockSetDeadline(t)
+}
+
+// SetReadDeadline calls MockSetReadDeadline.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.MockSetReadDeadline(t)
+}
+
+// SetWriteDeadline calls MockSetWriteDeadline.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return c.MockSetWriteDeadline(t)
+}

--- a/mocks/conn_test.go
+++ b/mocks/conn_test.go
@@ -1,0 +1,134 @@
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Adapted from: https://github.com/ooni/probe-cli/blob/v3.20.1/internal/mocks/dialer_test.go
+//
+
+package mocks
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConn(t *testing.T) {
+	t.Run("Read", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		c := &Conn{
+			MockRead: func(b []byte) (int, error) {
+				return 0, expected
+			},
+		}
+		count, err := c.Read(make([]byte, 128))
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+		if count != 0 {
+			t.Fatal("expected 0 bytes")
+		}
+	})
+
+	t.Run("Write", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		c := &Conn{
+			MockWrite: func(b []byte) (int, error) {
+				return 0, expected
+			},
+		}
+		count, err := c.Write(make([]byte, 128))
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+		if count != 0 {
+			t.Fatal("expected 0 bytes")
+		}
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		c := &Conn{
+			MockClose: func() error {
+				return expected
+			},
+		}
+		err := c.Close()
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("LocalAddr", func(t *testing.T) {
+		expected := &net.TCPAddr{
+			IP:   net.IPv6loopback,
+			Port: 1234,
+		}
+		c := &Conn{
+			MockLocalAddr: func() net.Addr {
+				return expected
+			},
+		}
+		out := c.LocalAddr()
+		if diff := cmp.Diff(expected, out); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("RemoteAddr", func(t *testing.T) {
+		expected := &net.TCPAddr{
+			IP:   net.IPv6loopback,
+			Port: 1234,
+		}
+		c := &Conn{
+			MockRemoteAddr: func() net.Addr {
+				return expected
+			},
+		}
+		out := c.RemoteAddr()
+		if diff := cmp.Diff(expected, out); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("SetDeadline", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		c := &Conn{
+			MockSetDeadline: func(t time.Time) error {
+				return expected
+			},
+		}
+		err := c.SetDeadline(time.Time{})
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected", err)
+		}
+	})
+
+	t.Run("SetReadDeadline", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		c := &Conn{
+			MockSetReadDeadline: func(t time.Time) error {
+				return expected
+			},
+		}
+		err := c.SetReadDeadline(time.Time{})
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected", err)
+		}
+	})
+
+	t.Run("SetWriteDeadline", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		c := &Conn{
+			MockSetWriteDeadline: func(t time.Time) error {
+				return expected
+			},
+		}
+		err := c.SetWriteDeadline(time.Time{})
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected", err)
+		}
+	})
+}

--- a/mocks/http.go
+++ b/mocks/http.go
@@ -1,0 +1,20 @@
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Adapted from: https://github.com/ooni/probe-cli/blob/v3.20.1/internal/mocks/http.go
+//
+
+package mocks
+
+import "net/http"
+
+// HTTPTransport mocks [http.RoundTripper].
+type HTTPTransport struct {
+	// MockRoundTrip is the function to call when RoundTrip is called.
+	MockRoundTrip func(req *http.Request) (*http.Response, error)
+}
+
+// RoundTrip calls MockRoundTrip.
+func (txp *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return txp.MockRoundTrip(req)
+}

--- a/mocks/http_test.go
+++ b/mocks/http_test.go
@@ -1,0 +1,31 @@
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Adapted from: https://github.com/ooni/probe-cli/blob/v3.20.1/internal/mocks/http_test.go
+//
+
+package mocks
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestHTTPTransport(t *testing.T) {
+	t.Run("RoundTrip", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		txp := &HTTPTransport{
+			MockRoundTrip: func(req *http.Request) (*http.Response, error) {
+				return nil, expected
+			},
+		}
+		resp, err := txp.RoundTrip(&http.Request{})
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected", err)
+		}
+		if resp != nil {
+			t.Fatal("expected nil response here")
+		}
+	})
+}


### PR DESCRIPTION
These mocks are general enough to warrant inclusion into the common libraries, so that we can reuse them.