### PR TITLE
fix(go.yml): do not rely on go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,14 @@ on:
 jobs:
 
   build:
+    strategy:
+      matrix:
+        goversion:
+          # The first entry of the matrix should be the
+          # version indicated inside the `go.mod`
+          - "1.23"
+          - "tip"
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -19,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: "${{ matrix.goversion }}"
 
     - name: Build
       run: go build ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,6 @@ jobs:
           # The first entry of the matrix should be the
           # version indicated inside the `go.mod`
           - "1.23"
-          - "tip"
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The version indicated in the go.mod file is the minimum required version of Go, so bumping it frequently is wrong.

As an alternative, create a matrix with supported versions of Go.