### PR TITLE
BREAKING CHANGE: HelpRequested: only consider `help` as 2nd argument

### DIFF
--- a/cliutils/cliutils_test.go
+++ b/cliutils/cliutils_test.go
@@ -89,23 +89,44 @@ func TestHelpRequested(t *testing.T) {
 	}
 
 	cases := []testcase{
+		// Empty argv and absence of any argument
 		{
-			argv:   []string{"--log-file", "log.jsonl", "-h"},
+			argv:   []string{},
+			expect: false,
+		},
+		{
+			argv:   []string{"dig"},
+			expect: false,
+		},
+
+		// Standalone help, help followed by arguments, help not as
+		// the second position in the argv
+		{
+			argv:   []string{"dig", "help"},
+			expect: true,
+		},
+		{
+			argv:   []string{"dig", "help", "log.jsonl"},
+			expect: true,
+		},
+		{
+			argv:   []string{"dig", "--log-file", "log.jsonl", "help"},
+			expect: false,
+		},
+
+		// With -h or --help as the last argument
+		{
+			argv:   []string{"dig", "--log-file", "log.jsonl", "-h"},
+			expect: true,
+		},
+		{
+			argv:   []string{"dig", "--log-file", "log.jsonl", "--help"},
 			expect: true,
 		},
 
+		// Without any of -h, --help, or help
 		{
-			argv:   []string{"--log-file", "log.jsonl", "help"},
-			expect: true,
-		},
-
-		{
-			argv:   []string{"--log-file", "log.jsonl", "--help"},
-			expect: true,
-		},
-
-		{
-			argv:   []string{"--log-file", "log.jsonl"},
+			argv:   []string{"dig", "--log-file", "log.jsonl"},
 			expect: false,
 		},
 	}

--- a/cliutils/clutils.go
+++ b/cliutils/clutils.go
@@ -133,14 +133,15 @@ func (dc defaultCommand) Main(ctx context.Context, argv ...string) error {
 }
 
 // HelpRequested reads the argv and returns whether it contains
-// one of `-h`, `--help`, and `help`. If this happens a subcommand
-// should invoke its own help method to print help.
+// one of `-h`, `--help`, in any position, or `help` as the first
+// element in the vector. If this happens a subcommand should
+// invoke its own help method to print help.
 func HelpRequested(argv ...string) bool {
 	for _, arg := range argv {
 		switch {
-		case arg == "-h" || arg == "--help" || arg == "help":
+		case arg == "-h" || arg == "--help":
 			return true
 		}
 	}
-	return false
+	return len(argv) > 1 && argv[1] == "help"
 }


### PR DESCRIPTION
This change is to increase CLI correctness and flexibility.

The following invocations:

```
dig help
dig help <topic>
```

continue to work as intended. Conversely:

```
dig @8.8.8.8 A help
```

should not produce the help screen rather should try to resolve `help`.