### PR TITLE
feat: add dialonce to prevent dialing loops

### DIFF
--- a/dialonce/dialonce.go
+++ b/dialonce/dialonce.go
@@ -15,11 +15,6 @@ type DialContextFunc = func(ctx context.Context, network, address string) (net.C
 
 // singleDialer ensures we dial just once.
 //
-// Test case: https://avdox.globalvoices.org/ seems to enter
-// the Go &http.Client{} into a loop (WTF?!) so as a mitigation
-// until we understand the issue, and perhaps in general, make
-// sure there is just a single dial per host.
-//
 // The zero value is ready to use.
 type singleDialer struct {
 	count atomic.Int32

--- a/dialonce/dialonce.go
+++ b/dialonce/dialonce.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package dialonce provides a way to ensure we dial just once.
+package dialonce
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+)
+
+// DialContextFunc is the function that dials a network connection with the given network and address.
+type DialContextFunc = func(ctx context.Context, network, address string) (net.Conn, error)
+
+// singleDialer ensures we dial just once.
+//
+// Test case: https://avdox.globalvoices.org/ seems to enter
+// the Go &http.Client{} into a loop (WTF?!) so as a mitigation
+// until we understand the issue, and perhaps in general, make
+// sure there is just a single dial per host.
+//
+// The zero value is ready to use.
+type singleDialer struct {
+	count atomic.Int32
+	dial  DialContextFunc
+}
+
+// ErrMultipleDial is the error returned when we dial more than once.
+var ErrMultipleDial = errors.New("dialing more than once")
+
+// DialContext dials a network connection with the given network and address.
+func (d *singleDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if d.count.Add(1) > 1 {
+		return nil, ErrMultipleDial
+	}
+	return d.dial(ctx, network, address)
+}
+
+// Wrap wraps a [DialContextFunc] to ensure we dial just once.
+//
+// Multiple attempts to dial will return [ErrMultipleDial].
+func Wrap(dial DialContextFunc) DialContextFunc {
+	return (&singleDialer{count: atomic.Int32{}, dial: dial}).DialContext
+}

--- a/dialonce/dialonce_test.go
+++ b/dialonce/dialonce_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dialonce
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+// mockConn is a minimal implementation of net.Conn for testing
+type mockConn struct {
+	net.Conn // embedded to provide default implementations
+}
+
+func TestWrap(t *testing.T) {
+	t.Run("successful single dial", func(t *testing.T) {
+		dialCount := 0
+		mockDial := func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialCount++
+			return &mockConn{}, nil
+		}
+
+		wrapped := Wrap(mockDial)
+		conn, err := wrapped(context.Background(), "tcp", "example.com:80")
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if conn == nil {
+			t.Error("expected connection, got nil")
+		}
+		if dialCount != 1 {
+			t.Errorf("expected dial count 1, got %d", dialCount)
+		}
+	})
+
+	t.Run("prevents multiple dials", func(t *testing.T) {
+		dialCount := 0
+		mockDial := func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialCount++
+			return &mockConn{}, nil
+		}
+
+		wrapped := Wrap(mockDial)
+
+		// First dial should succeed
+		conn1, err1 := wrapped(context.Background(), "tcp", "example.com:80")
+		if err1 != nil {
+			t.Errorf("first dial: unexpected error: %v", err1)
+		}
+		if conn1 == nil {
+			t.Error("first dial: expected connection, got nil")
+		}
+
+		// Second dial should fail
+		conn2, err2 := wrapped(context.Background(), "tcp", "example.com:80")
+		if !errors.Is(err2, ErrMultipleDial) {
+			t.Errorf("second dial: expected ErrMultipleDial, got %v", err2)
+		}
+		if conn2 != nil {
+			t.Error("second dial: expected nil connection")
+		}
+		if dialCount != 1 {
+			t.Errorf("expected dial count 1, got %d", dialCount)
+		}
+	})
+
+	t.Run("preserves underlying dial errors", func(t *testing.T) {
+		expectedErr := errors.New("dial error")
+		mockDial := func(ctx context.Context, network, address string) (net.Conn, error) {
+			return nil, expectedErr
+		}
+
+		wrapped := Wrap(mockDial)
+		conn, err := wrapped(context.Background(), "tcp", "example.com:80")
+
+		if !errors.Is(err, expectedErr) {
+			t.Errorf("expected error %v, got %v", expectedErr, err)
+		}
+		if conn != nil {
+			t.Error("expected nil connection")
+		}
+	})
+}


### PR DESCRIPTION
This commit introduces a new package, dialonce, ensuring each endpoint is dialed (and hence measured) at most once.

We introduce this package to address an issue where https://advox.globalvoices.org/ triggers infinite TLS dialing in Go's default HTTP client.

Example of the issue:

```Go
package main

import "net/http"

func main() {
	url := "https://advox.globalvoices.org/"
	client := &http.Client{}
	resp, err := client.Get(url)
	if err != nil {
		panic(err)
	}
	_ = resp
}
```

This code enters into a dial TLS loop lasting forever.