### PR TITLE
feat: import closepool and errclass from rbmk-project/x

### DIFF
--- a/closepool/closepool.go
+++ b/closepool/closepool.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package closepool allows pooling [io.Closer] instances
+// and closing them in a single operation.
+package closepool
+
+import (
+	"errors"
+	"io"
+	"slices"
+	"sync"
+)
+
+// Pool allows pooling a set of [io.Closer].
+//
+// The zero value is ready to use.
+type Pool struct {
+	// handles contains the [io.Closer] to close.
+	handles []io.Closer
+
+	// mu provides mutual exclusion.
+	mu sync.Mutex
+}
+
+// Add adds a given [io.Closer] to the pool.
+func (p *Pool) Add(conn io.Closer) {
+	p.mu.Lock()
+	p.handles = append(p.handles, conn)
+	p.mu.Unlock()
+}
+
+// Close closes all the [io.Closer] inside the pool iterating
+// in backward order. Therefore, if one registers a TCP connection
+// and then the corresponding TLS connection, the TLS connection
+// is closed first. The returned error is the join of all the
+// errors that occurred when closing connections.
+func (p *Pool) Close() error {
+	// Lock and copy the [io.Closer] to close.
+	p.mu.Lock()
+	handles := p.handles
+	p.handles = nil
+	p.mu.Unlock()
+
+	// Close all the [io.Closer].
+	var errv []error
+	for _, handle := range slices.Backward(handles) {
+		if err := handle.Close(); err != nil {
+			errv = append(errv, err)
+		}
+	}
+	return errors.Join(errv...)
+}

--- a/closepool/closepool_test.go
+++ b/closepool/closepool_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package closepool_test
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rbmk-project/common/closepool"
+)
+
+// mockCloser implements io.Closer for testing
+type mockCloser struct {
+	closed atomic.Int64
+	err    error
+}
+
+// t0 is the time when we started running
+var t0 = time.Now()
+
+func (m *mockCloser) Close() error {
+	m.closed.Add(int64(time.Since(t0)))
+	return m.err
+}
+
+func TestPool(t *testing.T) {
+	t.Run("successful close", func(t *testing.T) {
+		pool := closepool.Pool{}
+		m1 := &mockCloser{}
+		m2 := &mockCloser{}
+
+		pool.Add(m1)
+		pool.Add(m2)
+
+		err := pool.Close()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		if m1.closed.Load() <= 0 {
+			t.Error("first closer was not closed")
+		}
+		if m2.closed.Load() <= 0 {
+			t.Error("second closer was not closed")
+		}
+	})
+
+	t.Run("close order", func(t *testing.T) {
+		pool := closepool.Pool{}
+
+		m1 := &mockCloser{
+			err: nil,
+		}
+		m2 := &mockCloser{
+			err: nil,
+		}
+
+		pool.Add(m1) // Added first
+		pool.Add(m2) // Added second
+
+		// Should close in reverse order
+		err := pool.Close()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		if m1.closed.Load() <= m2.closed.Load() {
+			t.Error("expected m1 to be closed after m2")
+		}
+	})
+
+	t.Run("error handling", func(t *testing.T) {
+		pool := closepool.Pool{}
+		expectedErr1 := errors.New("close error #1")
+		expectedErr2 := errors.New("close error #2")
+
+		m1 := &mockCloser{err: expectedErr1}
+		m2 := &mockCloser{err: expectedErr2}
+
+		pool.Add(m1)
+		pool.Add(m2)
+
+		err := pool.Close()
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+
+		t.Log(err)
+		if errors.Join(expectedErr2, expectedErr1).Error() != err.Error() {
+			t.Errorf("expected error to include both errors, got %v", err)
+		}
+	})
+
+	t.Run("concurrent usage", func(t *testing.T) {
+		pool := closepool.Pool{}
+		done := make(chan struct{})
+
+		// Concurrently add closers
+		go func() {
+			for i := 0; i < 100; i++ {
+				pool.Add(&mockCloser{})
+			}
+			close(done)
+		}()
+
+		// Add more closers from main goroutine
+		for i := 0; i < 100; i++ {
+			pool.Add(&mockCloser{})
+		}
+
+		<-done // Wait for goroutine to finish
+
+		err := pool.Close()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/errclass/errclass.go
+++ b/errclass/errclass.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/*
+Package errclass implements error classification.
+
+The general idea is to classify golang errors to an enum of strings
+with names resembling standard Unix error names.
+
+# Design Principles
+
+1. Preserve original error in `err` in the structured logs.
+
+2. Add the classified error as the `errClass` field.
+
+3. Use [errors.Is] and [errors.As] for classification.
+
+4. Use string-based classification for readability.
+
+5. Follow Unix-like naming where appropriate.
+
+6. Prefix subsystem-specific errors (`EDNS_`, `ETLS_`).
+
+7. Keep full names for clarity over brevity.
+
+8. Map the nil error to an empty string.
+
+# System and Network Errors
+
+- [ETIMEDOUT] for [context.DeadlineExceeded], [os.ErrDeadlineExceeded]
+
+- [EINTR] for [context.Canceled], [net.ErrClosed]
+
+- [EEOF] for (unexpected) [io.EOF] and [io.ErrUnexpectedEOF] errors
+
+- [ECONNRESET], [ECONNREFUSED], ... for respective syscall errors
+
+The actual system error constants are defined in platform-specific files:
+
+- unix.go for Unix-like systems using x/sys/unix
+
+- windows.go for Windows systems using x/sys/windows
+
+This ensures proper mapping between the standardized error classes and
+platform-specific error constants.
+
+# DNS Errors
+
+- [EDNS_NONAME] for errors with the "no such host" suffix
+
+- [EDNS_NODATA] for errors with the "no answer" suffix
+
+# TLS
+
+- [ETLS_HOSTNAME_MISMATCH] for hostname verification failure
+
+- [ETLS_CA_UNKNOWN] for unknown certificate authority
+
+- [ETLS_CERT_INVALID] for invalid certificate
+
+# Fallback
+
+- [EGENERIC] for unclassified errors
+*/
+package errclass
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"strings"
+)
+
+const (
+	//
+	// Errors that we can map using [errors.Is]:
+	//
+
+	// EADDRNOTAVAIL is the address not available error.
+	EADDRNOTAVAIL = "EADDRNOTAVAIL"
+
+	// EADDRINUSE is the address in use error.
+	EADDRINUSE = "EADDRINUSE"
+
+	// ECONNABORTED is the connection aborted error.
+	ECONNABORTED = "ECONNABORTED"
+
+	// ECONNREFUSED is the connection refused error.
+	ECONNREFUSED = "ECONNREFUSED"
+
+	// ECONNRESET is the connection reset by peer error.
+	ECONNRESET = "ECONNRESET"
+
+	// EHOSTUNREACH is the host unreachable error.
+	EHOSTUNREACH = "EHOSTUNREACH"
+
+	// EEOF indicates an unexpected EOF.
+	EEOF = "EEOF"
+
+	// EINVAL is the invalid argument error.
+	EINVAL = "EINVAL"
+
+	// EINTR is the interrupted system call error.
+	EINTR = "EINTR"
+
+	// ENETDOWN is the network is down error.
+	ENETDOWN = "ENETDOWN"
+
+	// ENETUNREACH is the network unreachable error.
+	ENETUNREACH = "ENETUNREACH"
+
+	// ENOBUFS is the no buffer space available error.
+	ENOBUFS = "ENOBUFS"
+
+	// ENOTCONN is the not connected error.
+	ENOTCONN = "ENOTCONN"
+
+	// EPROTONOSUPPORT is the protocol not supported error.
+	EPROTONOSUPPORT = "EPROTONOSUPPORT"
+
+	// ETIMEDOUT is the operation timed out error.
+	ETIMEDOUT = "ETIMEDOUT"
+
+	//
+	// Errors that we can map using the error message suffix:
+	//
+
+	// EDNS_NONAME is the DNS error for "no such host".
+	EDNS_NONAME = "EDNS_NONAME"
+
+	// EDNS_NODATA 	is the DNS error for "no answer".
+	EDNS_NODATA = "EDNS_NODATA"
+
+	//
+	// Errors that we can map using [errors.As]:
+	//
+
+	// ETLS_HOSTNAME_MISMATCH is the TLS error for hostname verification failure.
+	ETLS_HOSTNAME_MISMATCH = "ETLS_HOSTNAME_MISMATCH"
+
+	// ETLS_CA_UNKNOWN is the TLS error for unknown certificate authority.
+	ETLS_CA_UNKNOWN = "ETLS_CA_UNKNOWN"
+
+	// ETLS_CERT_INVALID is the TLS error for invalid certificate.
+	ETLS_CERT_INVALID = "ETLS_CERT_INVALID"
+
+	//
+	// Fallback errors:
+	//
+
+	// EGENERIC is the generic, unclassified error.
+	EGENERIC = "EGENERIC"
+)
+
+// errorsIsMap contains the errors that we can map with [errors.Is].
+var errorsIsMap = map[error]string{
+	context.DeadlineExceeded: ETIMEDOUT,
+	context.Canceled:         EINTR,
+	errEADDRNOTAVAIL:         EADDRNOTAVAIL,
+	errEADDRINUSE:            EADDRINUSE,
+	errECONNABORTED:          ECONNABORTED,
+	errECONNREFUSED:          ECONNREFUSED,
+	errECONNRESET:            ECONNRESET,
+	errEHOSTUNREACH:          EHOSTUNREACH,
+	io.EOF:                   EEOF,
+	io.ErrUnexpectedEOF:      EEOF,
+	errEINVAL:                EINVAL,
+	errEINTR:                 EINTR,
+	errENETDOWN:              ENETDOWN,
+	errENETUNREACH:           ENETUNREACH,
+	errENOBUFS:               ENOBUFS,
+	errENOTCONN:              ENOTCONN,
+	errEPROTONOSUPPORT:       EPROTONOSUPPORT,
+	errETIMEDOUT:             ETIMEDOUT,
+	net.ErrClosed:            EINTR,
+	os.ErrDeadlineExceeded:   ETIMEDOUT,
+}
+
+// stringSuffixMap contains the errors that we can map using the error message suffix.
+var stringSuffixMap = map[string]string{
+	"no answer from DNS server": EDNS_NODATA,
+	"no such host":              EDNS_NONAME,
+}
+
+// errorsAsList contains the errors that we can map with [errors.As].
+var errorsAsList = []struct {
+	as    func(err error) bool
+	class string
+}{
+	{
+		as: func(err error) bool {
+			var candidate x509.HostnameError
+			return errors.As(err, &candidate)
+		},
+		class: ETLS_HOSTNAME_MISMATCH,
+	},
+
+	{
+		as: func(err error) bool {
+			var candidate x509.UnknownAuthorityError
+			return errors.As(err, &candidate)
+		},
+		class: ETLS_CA_UNKNOWN,
+	},
+
+	{
+		as: func(err error) bool {
+			var candidate x509.CertificateInvalidError
+			return errors.As(err, &candidate)
+		},
+		class: ETLS_CERT_INVALID,
+	},
+}
+
+// New creates a new error class from the given error.
+func New(err error) string {
+	// exclude the nil error case first
+	if err == nil {
+		return ""
+	}
+
+	// attemp direct mapping using the [errors.Is] func
+	for candidate, class := range errorsIsMap {
+		if errors.Is(err, candidate) {
+			return class
+		}
+	}
+
+	// attempt indirect mapping using the [errors.As] func
+	for _, entry := range errorsAsList {
+		if entry.as(err) {
+			return entry.class
+		}
+	}
+
+	// fallback to attempt matching with the string suffix
+	for suffix, class := range stringSuffixMap {
+		if strings.HasSuffix(err.Error(), suffix) {
+			return class
+		}
+	}
+
+	// we don't known this error
+	return EGENERIC
+}

--- a/errclass/errclass_test.go
+++ b/errclass/errclass_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package errclass
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	// testcase is a test case implemented by this function.
+	type testcase struct {
+		input  error
+		expect string
+	}
+
+	// start with a test case for the nil error
+	var tests = []testcase{
+		{
+			input:  nil,
+			expect: "",
+		},
+	}
+
+	// add tests for cases we can test with errors.Is
+	for key, value := range errorsIsMap {
+		tests = append(tests, testcase{
+			input:  key,
+			expect: value,
+		})
+	}
+
+	// add tests for cases we can test with string suffix matching
+	for suffix, class := range stringSuffixMap {
+		tests = append(tests, testcase{
+			input:  errors.New("some error message " + suffix),
+			expect: class,
+		})
+	}
+
+	// add tests for cases we can test with errors.As
+	tests = append(tests, testcase{
+		input: x509.HostnameError{
+			Certificate: &x509.Certificate{},
+			Host:        "",
+		},
+		expect: ETLS_HOSTNAME_MISMATCH,
+	})
+	tests = append(tests, testcase{
+		input: x509.UnknownAuthorityError{
+			Cert: &x509.Certificate{},
+		},
+		expect: ETLS_CA_UNKNOWN,
+	})
+	tests = append(tests, testcase{
+		input: x509.CertificateInvalidError{
+			Cert:   &x509.Certificate{},
+			Reason: 0,
+			Detail: "",
+		},
+		expect: ETLS_CERT_INVALID,
+	})
+
+	// add test for unknown error
+	tests = append(tests, testcase{
+		input:  errors.New("unknown error"),
+		expect: EGENERIC,
+	})
+
+	// run all tests
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.input), func(t *testing.T) {
+			got := New(tt.input)
+			if got != tt.expect {
+				t.Errorf("New(%v) = %v; want %v", tt.input, got, tt.expect)
+			}
+		})
+	}
+}

--- a/errclass/unix.go
+++ b/errclass/unix.go
@@ -1,0 +1,24 @@
+//go:build unix
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package errclass
+
+import "golang.org/x/sys/unix"
+
+const (
+	errEADDRNOTAVAIL   = unix.EADDRNOTAVAIL
+	errEADDRINUSE      = unix.EADDRINUSE
+	errECONNABORTED    = unix.ECONNABORTED
+	errECONNREFUSED    = unix.ECONNREFUSED
+	errECONNRESET      = unix.ECONNRESET
+	errEHOSTUNREACH    = unix.EHOSTUNREACH
+	errEINVAL          = unix.EINVAL
+	errEINTR           = unix.EINTR
+	errENETDOWN        = unix.ENETDOWN
+	errENETUNREACH     = unix.ENETUNREACH
+	errENOBUFS         = unix.ENOBUFS
+	errENOTCONN        = unix.ENOTCONN
+	errEPROTONOSUPPORT = unix.EPROTONOSUPPORT
+	errETIMEDOUT       = unix.ETIMEDOUT
+)

--- a/errclass/windows.go
+++ b/errclass/windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package errclass
+
+import "golang.org/x/sys/windows"
+
+const (
+	errEADDRNOTAVAIL   = windows.WSAEADDRNOTAVAIL
+	errEADDRINUSE      = windows.WSAEADDRINUSE
+	errECONNABORTED    = windows.WSAECONNABORTED
+	errECONNREFUSED    = windows.WSAECONNREFUSED
+	errECONNRESET      = windows.WSAECONNRESET
+	errEHOSTUNREACH    = windows.WSAEHOSTUNREACH
+	errEINVAL          = windows.WSAEINVAL
+	errEINTR           = windows.WSAEINTR
+	errENETDOWN        = windows.WSAENETDOWN
+	errENETUNREACH     = windows.WSAENETUNREACH
+	errENOBUFS         = windows.WSAENOBUFS
+	errENOTCONN        = windows.WSAENOTCONN
+	errEPROTONOSUPPORT = windows.WSAEPROTONOSUPPORT
+	errETIMEDOUT       = windows.WSAETIMEDOUT
+)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/rbmk-project/common
 
 go 1.23.3
 
-require github.com/google/go-cmp v0.6.0
+require (
+	github.com/google/go-cmp v0.6.0
+	golang.org/x/sys v0.27.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
These two packages are well tested and, IMHO, stable enough at this point to justify putting them into the common libs.

I will follow up and deprecate them inside the `x` collection.