### PR TITLE
chore: import netipx from rbmk-project/x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,12 @@ go 1.23.3
 
 require (
 	github.com/google/go-cmp v0.6.0
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.27.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/netipx/netipx.go
+++ b/netipx/netipx.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package netipx contains [net/netip] extensions.
+package netipx
+
+import (
+	"net"
+	"net/netip"
+)
+
+// AddrToAddrPort converts a [net.Addr] to a [netip.AddrPort].
+//
+// If the input is nil or neither a [*net.TCPAddr] nor [*net.UDPAddr],
+// returns an unspecified IPv6 address with port 0.
+//
+// For [*net.TCPAddr] and [*net.UDPAddr] addresses, returns their
+// corresponding [netip.AddrPort] representation.
+func AddrToAddrPort(addr net.Addr) netip.AddrPort {
+	if addr == nil {
+		return netip.AddrPortFrom(netip.IPv6Unspecified(), 0)
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		return tcp.AddrPort()
+	}
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		return udp.AddrPort()
+	}
+	return netip.AddrPortFrom(netip.IPv6Unspecified(), 0)
+}

--- a/netipx/netipx_test.go
+++ b/netipx/netipx_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netipx_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/rbmk-project/common/netipx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddrToAddrPort(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.Addr
+		want netip.AddrPort
+	}{
+		{
+			name: "nil address",
+			addr: nil,
+			want: netip.AddrPortFrom(netip.IPv6Unspecified(), 0),
+		},
+
+		{
+			name: "TCP address",
+			addr: &net.TCPAddr{
+				IP:   net.ParseIP("2001:db8::1"),
+				Port: 1234,
+			},
+			want: netip.MustParseAddrPort("[2001:db8::1]:1234"),
+		},
+
+		{
+			name: "UDP address",
+			addr: &net.UDPAddr{
+				IP:   net.ParseIP("2001:db8::2"),
+				Port: 5678,
+			},
+			want: netip.MustParseAddrPort("[2001:db8::2]:5678"),
+		},
+
+		{
+			name: "other address type",
+			addr: &net.UnixAddr{},
+			want: netip.AddrPortFrom(netip.IPv6Unspecified(), 0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := netipx.AddrToAddrPort(tt.addr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
I cannot actually add netipx to x because the x package depends on dnscore, so dnscore cannot depend on x.

While this is annoying, it's also true that netipx is good enough to qualify for being inside the common package collection.

Therefore, just move it here and I'll update `x` accordingly.