### PR TITLE
BREAKING CHANGE(cliutils): inject command Environment

### DIFF
--- a/climain/climain.go
+++ b/climain/climain.go
@@ -46,7 +46,8 @@ func Run(cmd cliutils.Command, exitfn ExitFunc, argv ...string) {
 	}()
 
 	// 3. run the selected command.
-	if err := cmd.Main(ctx, argv...); err != nil {
+	env := &cliutils.StandardEnvironment{}
+	if err := cmd.Main(ctx, env, argv...); err != nil {
 		exitfn(1)
 	}
 }

--- a/climain/climain.go
+++ b/climain/climain.go
@@ -46,7 +46,7 @@ func Run(cmd cliutils.Command, exitfn ExitFunc, argv ...string) {
 	}()
 
 	// 3. run the selected command.
-	env := &cliutils.StandardEnvironment{}
+	env := cliutils.StandardEnvironment{}
 	if err := cmd.Main(ctx, env, argv...); err != nil {
 		exitfn(1)
 	}

--- a/climain/climain_test.go
+++ b/climain/climain_test.go
@@ -19,12 +19,12 @@ type fakecmd struct {
 var _ cliutils.Command = fakecmd{}
 
 // Help implements [cliutils.Command].
-func (f fakecmd) Help(argv ...string) error {
+func (f fakecmd) Help(env cliutils.Environment, argv ...string) error {
 	return nil
 }
 
 // Main implements [cliutils.Command].
-func (f fakecmd) Main(ctx context.Context, argv ...string) error {
+func (f fakecmd) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	return f.err
 }
 

--- a/cliutils/cliutils_test.go
+++ b/cliutils/cliutils_test.go
@@ -28,7 +28,7 @@ func (f fakecmd) Main(ctx context.Context, env cliutils.Environment, argv ...str
 }
 
 func TestStandardEnvironment(t *testing.T) {
-	env := &cliutils.StandardEnvironment{}
+	env := cliutils.StandardEnvironment{}
 	if env.Stderr() != os.Stderr {
 		t.Fatal("expected os.Stderr")
 	}
@@ -76,7 +76,7 @@ func TestCommandWithSubCommands(t *testing.T) {
 					"env": fakecmd{},
 				},
 			)
-			stdenv := &cliutils.StandardEnvironment{}
+			stdenv := cliutils.StandardEnvironment{}
 			err := cmd.Main(context.Background(), stdenv, tc.argv...)
 			switch {
 			case tc.failure == "" && err == nil:


### PR DESCRIPTION
This diff modifies cliutils.Command to inject an Environment interface for both Help and Main, which provides the stdout and the stderr via methods. In turn, this change allows for a fine grained customisation of `rbmk` commands stdout and stderr, with immediate benefits for testing code, where we will be able to drop the current singleton based approach.