### PR TITLE
feat(cliutils): add Stdin to Environment

### DIFF
--- a/cliutils/cliutils_test.go
+++ b/cliutils/cliutils_test.go
@@ -29,6 +29,9 @@ func (f fakecmd) Main(ctx context.Context, env cliutils.Environment, argv ...str
 
 func TestStandardEnvironment(t *testing.T) {
 	env := cliutils.StandardEnvironment{}
+	if env.Stdin() != os.Stdin {
+		t.Fatal("expected os.Stdin")
+	}
 	if env.Stderr() != os.Stderr {
 		t.Fatal("expected os.Stderr")
 	}

--- a/cliutils/clutils.go
+++ b/cliutils/clutils.go
@@ -13,6 +13,9 @@ import (
 
 // Environment is the environment for executing a [Command].
 type Environment interface {
+	// Stdin returns the stdin reader to use.
+	Stdin() io.Reader
+
 	// Stderr returns the stderr writer to use.
 	Stderr() io.Writer
 
@@ -26,12 +29,17 @@ type StandardEnvironment struct{}
 // Ensure that [StandardEnvironment] implements [Environment].
 var _ Environment = StandardEnvironment{}
 
-// Stderr implements Environment.
+// Stdin implements [Environment].
+func (se StandardEnvironment) Stdin() io.Reader {
+	return os.Stdin
+}
+
+// Stderr implements [Environment].
 func (se StandardEnvironment) Stderr() io.Writer {
 	return os.Stderr
 }
 
-// Stdout implements Environment.
+// Stdout implements [Environment].
 func (se StandardEnvironment) Stdout() io.Writer {
 	return os.Stdout
 }


### PR DESCRIPTION
This diff adds Stdin to the Environment type, thus allowing to replace also the stdin when executing commands.

There is an `rbmk sh` command in `rbmk` and currently it unconditionally uses the os.Stdin, which does not seem about right and may backfire if we start to use commands in non-conventional ways (e.g., executing them by calling the Command.Main rather than spawning `rbmk <command>`).

So, because of all of this and because it seems cheap to avoid this potential future issue, pave the way for a stdin override inside of `rbmk` commands and subcommands.