### PR TITLE
feat(fsx): introduce file system abstraction

### DIFF
--- a/fsx/chdirfs.go
+++ b/fsx/chdirfs.go
@@ -1,0 +1,119 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from: https://github.com/spf13/afero
+//
+
+package fsx
+
+import (
+	"io/fs"
+	"net"
+	"path/filepath"
+	"time"
+)
+
+// NewChdirFS creates a new [FS] where each file name is
+// prefixed with the given directory path.
+func NewChdirFS(dep FS, path string) *ChdirFS {
+	return &ChdirFS{basepath: path, dep: dep}
+}
+
+// ChdirFS is the [FS] type returned by [NewChdirFS].
+//
+// The zero value IS NOT ready to use; construct using [NewChdirFS].
+type ChdirFS struct {
+	// basepath is the base path.
+	basepath string
+
+	// dep is the dependency [FS].
+	dep FS
+}
+
+// Ensure [basePathFS] implements [FS].
+var _ FS = &ChdirFS{}
+
+// realPath returns the real path of a given file name or an error.
+func (rfs *ChdirFS) realPath(name string) string {
+	return filepath.Join(rfs.basepath, name)
+}
+
+// Chmod implements [FS].
+func (rfs *ChdirFS) Chmod(name string, mode fs.FileMode) error {
+	return rfs.dep.Chmod(rfs.realPath(name), mode)
+}
+
+// Chown implements [FS].
+func (rfs *ChdirFS) Chown(name string, uid, gid int) error {
+	return rfs.dep.Chown(rfs.realPath(name), uid, gid)
+}
+
+// Chtimes implements [FS].
+func (rfs *ChdirFS) Chtimes(name string, atime, mtime time.Time) error {
+	return rfs.dep.Chtimes(rfs.realPath(name), atime, mtime)
+}
+
+// Create implements [FS].
+func (rfs *ChdirFS) Create(name string) (File, error) {
+	return rfs.dep.Create(rfs.realPath(name))
+}
+
+// DialUnix implements [FS].
+func (rfs *ChdirFS) DialUnix(name string) (net.Conn, error) {
+	return rfs.dep.DialUnix(rfs.realPath(name))
+}
+
+// ListenUnix implements [FS].
+func (rfs *ChdirFS) ListenUnix(name string) (net.Listener, error) {
+	return rfs.dep.ListenUnix(rfs.realPath(name))
+}
+
+// Lstat implements [FS].
+func (rfs *ChdirFS) Lstat(name string) (fs.FileInfo, error) {
+	return rfs.dep.Lstat(rfs.realPath(name))
+}
+
+// Mkdir implements [FS].
+func (rfs *ChdirFS) Mkdir(name string, mode fs.FileMode) error {
+	return rfs.dep.Mkdir(rfs.realPath(name), mode)
+}
+
+// MkdirAll implements [FS].
+func (rfs *ChdirFS) MkdirAll(name string, mode fs.FileMode) error {
+	return rfs.dep.MkdirAll(rfs.realPath(name), mode)
+}
+
+// Open implements [FS].
+func (rfs *ChdirFS) Open(name string) (File, error) {
+	return rfs.dep.Open(rfs.realPath(name))
+}
+
+// OpenFile implements [FS].
+func (rfs *ChdirFS) OpenFile(name string, flag int, mode fs.FileMode) (File, error) {
+	return rfs.dep.OpenFile(rfs.realPath(name), flag, mode)
+}
+
+// ReadDir implements [FS].
+func (rfs *ChdirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return rfs.dep.ReadDir(rfs.realPath(name))
+}
+
+// Remove implements [FS].
+func (rfs *ChdirFS) Remove(name string) error {
+	return rfs.dep.Remove(rfs.realPath(name))
+}
+
+// RemoveAll implements [FS].
+func (rfs *ChdirFS) RemoveAll(name string) error {
+	return rfs.dep.RemoveAll(rfs.realPath(name))
+}
+
+// Rename implements [FS].
+func (rfs *ChdirFS) Rename(oldname, newname string) error {
+	return rfs.dep.Rename(rfs.realPath(oldname), rfs.realPath(newname))
+}
+
+// Stat implements [FS].
+func (rfs *ChdirFS) Stat(name string) (fs.FileInfo, error) {
+	return rfs.dep.Stat(rfs.realPath(name))
+}

--- a/fsx/chdirfs_test.go
+++ b/fsx/chdirfs_test.go
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package fsx_test
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/rbmk-project/common/fsx"
+	"github.com/rbmk-project/common/mocks"
+)
+
+func TestChdirFS(t *testing.T) {
+	expected := errors.New("mocked error")
+
+	t.Run("Chmod", func(t *testing.T) {
+		expectedPath := "/base/attrs.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockChmod: func(name string, mode fs.FileMode) error {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		err := chdirFS.Chmod("attrs.txt", 0600)
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Chown", func(t *testing.T) {
+		expectedPath := "/base/attrs.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockChown: func(name string, uid, gid int) error {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		err := chdirFS.Chown("attrs.txt", 1000, 1000)
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Chtimes", func(t *testing.T) {
+		expectedPath := "/base/attrs.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockChtimes: func(name string, atime time.Time, mtime time.Time) error {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		err := chdirFS.Chtimes("attrs.txt", time.Now(), time.Now())
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		expectedPath := "/base/test.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockCreate: func(name string) (fsx.File, error) {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return nil, expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		_, err := chdirFS.Create("test.txt")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("DialUnix", func(t *testing.T) {
+		expectedPath := "/base/test.sock"
+		mockFS := &mocks.FsmodelFS{
+			MockDialUnix: func(name string) (net.Conn, error) {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return nil, expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		_, err := chdirFS.DialUnix("test.sock")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("ListenUnix", func(t *testing.T) {
+		expectedPath := "/base/test.sock"
+		mockFS := &mocks.FsmodelFS{
+			MockListenUnix: func(name string) (net.Listener, error) {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return nil, expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		_, err := chdirFS.ListenUnix("test.sock")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Lstat", func(t *testing.T) {
+		expectedPath := "/base/attrs.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockLstat: func(name string) (fs.FileInfo, error) {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return nil, expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		_, err := chdirFS.Lstat("attrs.txt")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Mkdir", func(t *testing.T) {
+		expectedPath := "/base/testdir"
+		mockFS := &mocks.FsmodelFS{
+			MockMkdir: func(name string, perm fs.FileMode) error {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		err := chdirFS.Mkdir("testdir", 0755)
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("MkdirAll", func(t *testing.T) {
+		expectedPath := "/base/testdir"
+		mockFS := &mocks.FsmodelFS{
+			MockMkdirAll: func(name string, perm fs.FileMode) error {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		err := chdirFS.MkdirAll("testdir", 0755)
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		expectedPath := "/base/test.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockOpen: func(name string) (fsx.File, error) {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return nil, expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		_, err := chdirFS.Open("test.txt")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("OpenFile", func(t *testing.T) {
+		expectedPath := "/base/modes.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockOpenFile: func(name string, flag int, perm fs.FileMode) (fsx.File, error) {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return nil, expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		_, err := chdirFS.OpenFile("modes.txt", fsx.O_CREATE|fsx.O_WRONLY, 0644)
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("ReadDir", func(t *testing.T) {
+		expectedPath := "/base/testdir"
+		mockFS := &mocks.FsmodelFS{
+			MockReadDir: func(dirname string) ([]fs.DirEntry, error) {
+				if dirname != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, dirname)
+				}
+				return nil, expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		_, err := chdirFS.ReadDir("testdir")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		expectedPath := "/base/remove.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockRemove: func(name string) error {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		err := chdirFS.Remove("remove.txt")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("RemoveAll", func(t *testing.T) {
+		expectedPath := "/base/removedir"
+		mockFS := &mocks.FsmodelFS{
+			MockRemoveAll: func(path string) error {
+				if path != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, path)
+				}
+				return expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		err := chdirFS.RemoveAll("removedir")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Rename", func(t *testing.T) {
+		expectedOldPath := "/base/old.txt"
+		expectedNewPath := "/base/new.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockRename: func(oldname, newname string) error {
+				if oldname != expectedOldPath || newname != expectedNewPath {
+					t.Fatalf("expected paths %q and %q, got %q and %q", expectedOldPath, expectedNewPath, oldname, newname)
+				}
+				return expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		err := chdirFS.Rename("old.txt", "new.txt")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("Stat", func(t *testing.T) {
+		expectedPath := "/base/attrs.txt"
+		mockFS := &mocks.FsmodelFS{
+			MockStat: func(name string) (fs.FileInfo, error) {
+				if name != expectedPath {
+					t.Fatalf("expected path %q, got %q", expectedPath, name)
+				}
+				return nil, expected
+			},
+		}
+		chdirFS := fsx.NewChdirFS(mockFS, "/base")
+
+		_, err := chdirFS.Stat("attrs.txt")
+
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+}

--- a/fsx/chdirfs_test.go
+++ b/fsx/chdirfs_test.go
@@ -18,7 +18,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Chmod", func(t *testing.T) {
 		expectedPath := "/base/attrs.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockChmod: func(name string, mode fs.FileMode) error {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -37,7 +37,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Chown", func(t *testing.T) {
 		expectedPath := "/base/attrs.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockChown: func(name string, uid, gid int) error {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -56,7 +56,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Chtimes", func(t *testing.T) {
 		expectedPath := "/base/attrs.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockChtimes: func(name string, atime time.Time, mtime time.Time) error {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -75,7 +75,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		expectedPath := "/base/test.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockCreate: func(name string) (fsx.File, error) {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -94,7 +94,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("DialUnix", func(t *testing.T) {
 		expectedPath := "/base/test.sock"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockDialUnix: func(name string) (net.Conn, error) {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -113,7 +113,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("ListenUnix", func(t *testing.T) {
 		expectedPath := "/base/test.sock"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockListenUnix: func(name string) (net.Listener, error) {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -132,7 +132,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Lstat", func(t *testing.T) {
 		expectedPath := "/base/attrs.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockLstat: func(name string) (fs.FileInfo, error) {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -151,7 +151,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Mkdir", func(t *testing.T) {
 		expectedPath := "/base/testdir"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockMkdir: func(name string, perm fs.FileMode) error {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -170,7 +170,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("MkdirAll", func(t *testing.T) {
 		expectedPath := "/base/testdir"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockMkdirAll: func(name string, perm fs.FileMode) error {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -189,7 +189,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Open", func(t *testing.T) {
 		expectedPath := "/base/test.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockOpen: func(name string) (fsx.File, error) {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -208,7 +208,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("OpenFile", func(t *testing.T) {
 		expectedPath := "/base/modes.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockOpenFile: func(name string, flag int, perm fs.FileMode) (fsx.File, error) {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -227,7 +227,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("ReadDir", func(t *testing.T) {
 		expectedPath := "/base/testdir"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockReadDir: func(dirname string) ([]fs.DirEntry, error) {
 				if dirname != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, dirname)
@@ -246,7 +246,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Remove", func(t *testing.T) {
 		expectedPath := "/base/remove.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockRemove: func(name string) error {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)
@@ -265,7 +265,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("RemoveAll", func(t *testing.T) {
 		expectedPath := "/base/removedir"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockRemoveAll: func(path string) error {
 				if path != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, path)
@@ -285,7 +285,7 @@ func TestChdirFS(t *testing.T) {
 	t.Run("Rename", func(t *testing.T) {
 		expectedOldPath := "/base/old.txt"
 		expectedNewPath := "/base/new.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockRename: func(oldname, newname string) error {
 				if oldname != expectedOldPath || newname != expectedNewPath {
 					t.Fatalf("expected paths %q and %q, got %q and %q", expectedOldPath, expectedNewPath, oldname, newname)
@@ -304,7 +304,7 @@ func TestChdirFS(t *testing.T) {
 
 	t.Run("Stat", func(t *testing.T) {
 		expectedPath := "/base/attrs.txt"
-		mockFS := &mocks.FsmodelFS{
+		mockFS := &mocks.FS{
 			MockStat: func(name string) (fs.FileInfo, error) {
 				if name != expectedPath {
 					t.Fatalf("expected path %q, got %q", expectedPath, name)

--- a/fsx/fsx.go
+++ b/fsx/fsx.go
@@ -12,13 +12,6 @@ This package is derived from [afero].
 In addition to [afero], we also implement support for dialing
 and listening unix domain sockets, and for Lstat.
 
-The [NewRelativeFS] creates a filesystem relative to a given
-directory that only allows:
-
-1. Accessing files within the base directory.
-
-2. Changing working directory to a subdirectory of the base directory.
-
 [afero]: https://github.com/spf13/afero
 */
 package fsx

--- a/fsx/fsx.go
+++ b/fsx/fsx.go
@@ -1,0 +1,56 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from: https://github.com/spf13/afero
+//
+
+/*
+Package fsx allows abstracting the file system.
+
+This package is derived from [afero].
+
+In addition to [afero], we also implement support for dialing
+and listening unix domain sockets, and for Lstat.
+
+The [NewRelativeFS] creates a filesystem relative to a given
+directory that only allows:
+
+1. Accessing files within the base directory.
+
+2. Changing working directory to a subdirectory of the base directory.
+
+[afero]: https://github.com/spf13/afero
+*/
+package fsx
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/rbmk-project/common/internal/fsmodel"
+)
+
+// Forward file system constants.
+const (
+	O_CREATE = fsmodel.O_CREATE
+	O_RDONLY = fsmodel.O_RDONLY
+	O_RDWR   = fsmodel.O_RDWR
+	O_TRUNC  = fsmodel.O_TRUNC
+	O_WRONLY = fsmodel.O_WRONLY
+)
+
+// IsNotExist combines the [os.ErrNotExist] check with
+// checking for the [fs.ErrNotExist] error.
+func IsNotExist(err error) bool {
+	return errors.Is(err, fs.ErrNotExist) || os.IsNotExist(err)
+}
+
+// File is an alias for [fsmodel.File].
+type File = fsmodel.File
+
+// Ensure [*os.File] implements [File].
+var _ File = &os.File{}
+
+// FS is an alias for [fsmodel.FS].
+type FS = fsmodel.FS

--- a/fsx/fsx_test.go
+++ b/fsx/fsx_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package fsx_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/rbmk-project/common/fsx"
+)
+
+func TestIsNotExist(t *testing.T) {
+	t.Run("fs.ErrNotExist", func(t *testing.T) {
+		err := fs.ErrNotExist
+		if !fsx.IsNotExist(err) {
+			t.Fatal("expected true, got false")
+		}
+	})
+
+	t.Run("os.ErrNotExist", func(t *testing.T) {
+		err := os.ErrNotExist
+		if !fsx.IsNotExist(err) {
+			t.Fatal("expected true, got false")
+		}
+	})
+
+	t.Run("other error", func(t *testing.T) {
+		err := errors.New("some other error")
+		if fsx.IsNotExist(err) {
+			t.Fatal("expected false, got true")
+		}
+	})
+}

--- a/fsx/osfs.go
+++ b/fsx/osfs.go
@@ -1,0 +1,154 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from: https://github.com/spf13/afero
+//
+
+package fsx
+
+import (
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"time"
+)
+
+// osFileWrapper wraps an [*os.File] to hide the methods that are
+// not defined by the [File] interface. This allows us to restrict
+// the operations actually possible with a file.
+type osFileWrapper struct {
+	filep io.ReadWriteCloser
+}
+
+var _ File = osFileWrapper{}
+
+// Close implements [File].
+func (fw osFileWrapper) Close() error {
+	return fw.filep.Close()
+}
+
+// Read implements [File].
+func (fw osFileWrapper) Read(buf []byte) (int, error) {
+	return fw.filep.Read(buf)
+}
+
+// Write implements [File].
+func (fw osFileWrapper) Write(data []byte) (int, error) {
+	return fw.filep.Write(data)
+}
+
+// maybeWrapOSFile wraps an [*os.File] into an [osFileWrapper] if the file
+// was successfully opened. Otherwise, it returns the error.
+func maybeWrapOSFile(filep io.ReadWriteCloser, err error) (File, error) {
+	switch {
+	case err != nil:
+		return nil, err
+	default:
+		return osFileWrapper{filep}, nil
+	}
+}
+
+// OsFS implements [FS] using the standard [os] package.
+//
+// The zero value is ready to use.
+type OsFS struct{}
+
+var (
+	osChmod       = os.Chmod
+	osChown       = os.Chown
+	osChtimes     = os.Chtimes
+	osCreate      = os.Create
+	netDialUnix   = net.DialUnix
+	netListenUnix = net.ListenUnix
+	osLstat       = os.Lstat
+	osMkdir       = os.Mkdir
+	osMkdirAll    = os.MkdirAll
+	osOpen        = os.Open
+	osOpenFile    = os.OpenFile
+	osReadDir     = os.ReadDir
+	osRemove      = os.Remove
+	osRemoveAll   = os.RemoveAll
+	osRename      = os.Rename
+	osStat        = os.Stat
+)
+
+// Chmod implements [FS].
+func (OsFS) Chmod(name string, mode fs.FileMode) error {
+	return osChmod(name, mode)
+}
+
+// Chown implements [FS].
+func (OsFS) Chown(name string, uid, gid int) error {
+	return osChown(name, uid, gid)
+}
+
+// Chtimes implements [FS].
+func (OsFS) Chtimes(name string, atime, mtime time.Time) error {
+	return osChtimes(name, atime, mtime)
+}
+
+// Create implements [FS].
+func (OsFS) Create(name string) (File, error) {
+	return maybeWrapOSFile(osCreate(name))
+}
+
+// DialUnix implements [FS].
+func (OsFS) DialUnix(name string) (net.Conn, error) {
+	return netDialUnix("unix", nil, &net.UnixAddr{Name: name, Net: "unix"})
+}
+
+// ListenUnix implements [FS].
+func (OsFS) ListenUnix(name string) (net.Listener, error) {
+	return netListenUnix("unix", &net.UnixAddr{Name: name, Net: "unix"})
+}
+
+// Lstat implements [FS].
+func (OsFS) Lstat(name string) (fs.FileInfo, error) {
+	return osLstat(name)
+}
+
+// Mkdir implements [FS].
+func (OsFS) Mkdir(name string, mode fs.FileMode) error {
+	return osMkdir(name, mode)
+}
+
+// MkdirAll implements [FS].
+func (OsFS) MkdirAll(name string, mode fs.FileMode) error {
+	return osMkdirAll(name, mode)
+}
+
+// Open implements [FS].
+func (OsFS) Open(name string) (File, error) {
+	return maybeWrapOSFile(osOpen(name))
+}
+
+// OpenFile implements [FS].
+func (OsFS) OpenFile(name string, flag int, mode fs.FileMode) (File, error) {
+	return maybeWrapOSFile(osOpenFile(name, flag, mode))
+}
+
+// ReadDir implements [FS].
+func (OsFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return osReadDir(name)
+}
+
+// Remove implements [FS].
+func (OsFS) Remove(name string) error {
+	return osRemove(name)
+}
+
+// RemoveAll implements [FS].
+func (OsFS) RemoveAll(name string) error {
+	return osRemoveAll(name)
+}
+
+// Rename implements [FS].
+func (OsFS) Rename(oldname, newname string) error {
+	return osRename(oldname, newname)
+}
+
+// Stat implements [FS].
+func (OsFS) Stat(name string) (os.FileInfo, error) {
+	return osStat(name)
+}

--- a/fsx/osfs_test.go
+++ b/fsx/osfs_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestOsFileWrapper(t *testing.T) {
 	t.Run("Close", func(t *testing.T) {
-		mockFile := &mocks.FsmodelFile{
+		mockFile := &mocks.File{
 			MockClose: func() error {
 				return errors.New("close error")
 			},
@@ -28,7 +28,7 @@ func TestOsFileWrapper(t *testing.T) {
 	})
 
 	t.Run("Read", func(t *testing.T) {
-		mockFile := &mocks.FsmodelFile{
+		mockFile := &mocks.File{
 			MockRead: func(b []byte) (int, error) {
 				return 0, errors.New("read error")
 			},
@@ -46,7 +46,7 @@ func TestOsFileWrapper(t *testing.T) {
 	})
 
 	t.Run("Write", func(t *testing.T) {
-		mockFile := &mocks.FsmodelFile{
+		mockFile := &mocks.File{
 			MockWrite: func(b []byte) (int, error) {
 				return 0, errors.New("write error")
 			},
@@ -66,7 +66,7 @@ func TestOsFileWrapper(t *testing.T) {
 
 func TestMaybeWrapOSFile(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		mockFile := &mocks.FsmodelFile{}
+		mockFile := &mocks.File{}
 		file, err := maybeWrapOSFile(mockFile, nil)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)

--- a/fsx/osfs_test.go
+++ b/fsx/osfs_test.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package fsx
+
+import (
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rbmk-project/common/mocks"
+)
+
+func TestOsFileWrapper(t *testing.T) {
+	t.Run("Close", func(t *testing.T) {
+		mockFile := &mocks.FsmodelFile{
+			MockClose: func() error {
+				return errors.New("close error")
+			},
+		}
+		fileWrapper := osFileWrapper{filep: mockFile}
+
+		err := fileWrapper.Close()
+		if err == nil || err.Error() != "close error" {
+			t.Errorf("expected close error, got %v", err)
+		}
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		mockFile := &mocks.FsmodelFile{
+			MockRead: func(b []byte) (int, error) {
+				return 0, errors.New("read error")
+			},
+		}
+		fileWrapper := osFileWrapper{filep: mockFile}
+
+		buf := make([]byte, 5)
+		n, err := fileWrapper.Read(buf)
+		if err == nil || err.Error() != "read error" {
+			t.Errorf("expected read error, got %v", err)
+		}
+		if n != 0 {
+			t.Errorf("expected to read 0 bytes, read %d", n)
+		}
+	})
+
+	t.Run("Write", func(t *testing.T) {
+		mockFile := &mocks.FsmodelFile{
+			MockWrite: func(b []byte) (int, error) {
+				return 0, errors.New("write error")
+			},
+		}
+		fileWrapper := osFileWrapper{filep: mockFile}
+
+		data := []byte("hello, world")
+		n, err := fileWrapper.Write(data)
+		if err == nil || err.Error() != "write error" {
+			t.Errorf("expected write error, got %v", err)
+		}
+		if n != 0 {
+			t.Errorf("expected to write 0 bytes, wrote %d", n)
+		}
+	})
+}
+
+func TestMaybeWrapOSFile(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		mockFile := &mocks.FsmodelFile{}
+		file, err := maybeWrapOSFile(mockFile, nil)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if file == nil {
+			t.Fatal("expected a file, got nil")
+		}
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		mockError := errors.New("open error")
+		file, err := maybeWrapOSFile(nil, mockError)
+		if err == nil || err.Error() != "open error" {
+			t.Errorf("expected open error, got %v", err)
+		}
+		if file != nil {
+			t.Errorf("expected nil file, got %v", file)
+		}
+	})
+}
+
+func TestOsFS(t *testing.T) {
+	filesystem := OsFS{}
+
+	t.Run("Chmod", func(t *testing.T) {
+		original := osChmod
+		defer func() { osChmod = original }()
+		osChmod = func(name string, mode os.FileMode) error {
+			return errors.New("chmod error")
+		}
+
+		err := filesystem.Chmod("dummy", 0644)
+		if err == nil || err.Error() != "chmod error" {
+			t.Errorf("expected chmod error, got %v", err)
+		}
+	})
+
+	t.Run("Chown", func(t *testing.T) {
+		original := osChown
+		defer func() { osChown = original }()
+		osChown = func(name string, uid, gid int) error {
+			return errors.New("chown error")
+		}
+
+		err := filesystem.Chown("dummy", 0, 0)
+		if err == nil || err.Error() != "chown error" {
+			t.Errorf("expected chown error, got %v", err)
+		}
+	})
+
+	t.Run("Chtimes", func(t *testing.T) {
+		original := osChtimes
+		defer func() { osChtimes = original }()
+		osChtimes = func(name string, atime, mtime time.Time) error {
+			return errors.New("chtimes error")
+		}
+
+		err := filesystem.Chtimes("dummy", time.Now(), time.Now())
+		if err == nil || err.Error() != "chtimes error" {
+			t.Errorf("expected chtimes error, got %v", err)
+		}
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		original := osCreate
+		defer func() { osCreate = original }()
+		osCreate = func(name string) (*os.File, error) {
+			return nil, errors.New("create error")
+		}
+
+		_, err := filesystem.Create("dummy")
+		if err == nil || err.Error() != "create error" {
+			t.Errorf("expected create error, got %v", err)
+		}
+	})
+
+	t.Run("DialUnix", func(t *testing.T) {
+		original := netDialUnix
+		defer func() { netDialUnix = original }()
+		netDialUnix = func(network string, laddr, raddr *net.UnixAddr) (*net.UnixConn, error) {
+			return nil, errors.New("dial unix error")
+		}
+
+		_, err := filesystem.DialUnix("dummy")
+		if err == nil || err.Error() != "dial unix error" {
+			t.Errorf("expected dial unix error, got %v", err)
+		}
+	})
+
+	t.Run("ListenUnix", func(t *testing.T) {
+		original := netListenUnix
+		defer func() { netListenUnix = original }()
+		netListenUnix = func(network string, laddr *net.UnixAddr) (*net.UnixListener, error) {
+			return nil, errors.New("listen unix error")
+		}
+
+		_, err := filesystem.ListenUnix("dummy")
+		if err == nil || err.Error() != "listen unix error" {
+			t.Errorf("expected listen unix error, got %v", err)
+		}
+	})
+
+	t.Run("Lstat", func(t *testing.T) {
+		original := osLstat
+		defer func() { osLstat = original }()
+		osLstat = func(name string) (os.FileInfo, error) {
+			return nil, errors.New("lstat error")
+		}
+
+		_, err := filesystem.Lstat("dummy")
+		if err == nil || err.Error() != "lstat error" {
+			t.Errorf("expected lstat error, got %v", err)
+		}
+	})
+
+	t.Run("Mkdir", func(t *testing.T) {
+		original := osMkdir
+		defer func() { osMkdir = original }()
+		osMkdir = func(name string, perm os.FileMode) error {
+			return errors.New("mkdir error")
+		}
+
+		err := filesystem.Mkdir("dummy", 0755)
+		if err == nil || err.Error() != "mkdir error" {
+			t.Errorf("expected mkdir error, got %v", err)
+		}
+	})
+
+	t.Run("MkdirAll", func(t *testing.T) {
+		original := osMkdirAll
+		defer func() { osMkdirAll = original }()
+		osMkdirAll = func(path string, perm os.FileMode) error {
+			return errors.New("mkdirall error")
+		}
+
+		err := filesystem.MkdirAll("dummy", 0755)
+		if err == nil || err.Error() != "mkdirall error" {
+			t.Errorf("expected mkdirall error, got %v", err)
+		}
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		original := osOpen
+		defer func() { osOpen = original }()
+		osOpen = func(name string) (*os.File, error) {
+			return nil, errors.New("open error")
+		}
+
+		_, err := filesystem.Open("dummy")
+		if err == nil || err.Error() != "open error" {
+			t.Errorf("expected open error, got %v", err)
+		}
+	})
+
+	t.Run("OpenFile", func(t *testing.T) {
+		original := osOpenFile
+		defer func() { osOpenFile = original }()
+		osOpenFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+			return nil, errors.New("openfile error")
+		}
+
+		_, err := filesystem.OpenFile("dummy", os.O_CREATE|os.O_WRONLY, 0644)
+		if err == nil || err.Error() != "openfile error" {
+			t.Errorf("expected openfile error, got %v", err)
+		}
+	})
+
+	t.Run("ReadDir", func(t *testing.T) {
+		original := osReadDir
+		defer func() { osReadDir = original }()
+		osReadDir = func(name string) ([]os.DirEntry, error) {
+			return nil, errors.New("readdir error")
+		}
+
+		_, err := filesystem.ReadDir("dummy")
+		if err == nil || err.Error() != "readdir error" {
+			t.Errorf("expected readdir error, got %v", err)
+		}
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		original := osRemove
+		defer func() { osRemove = original }()
+		osRemove = func(name string) error {
+			return errors.New("remove error")
+		}
+
+		err := filesystem.Remove("dummy")
+		if err == nil || err.Error() != "remove error" {
+			t.Errorf("expected remove error, got %v", err)
+		}
+	})
+
+	t.Run("RemoveAll", func(t *testing.T) {
+		original := osRemoveAll
+		defer func() { osRemoveAll = original }()
+		osRemoveAll = func(path string) error {
+			return errors.New("removeall error")
+		}
+
+		err := filesystem.RemoveAll("dummy")
+		if err == nil || err.Error() != "removeall error" {
+			t.Errorf("expected removeall error, got %v", err)
+		}
+	})
+
+	t.Run("Rename", func(t *testing.T) {
+		original := osRename
+		defer func() { osRename = original }()
+		osRename = func(oldpath, newpath string) error {
+			return errors.New("rename error")
+		}
+
+		err := filesystem.Rename("old", "new")
+		if err == nil || err.Error() != "rename error" {
+			t.Errorf("expected rename error, got %v", err)
+		}
+	})
+
+	t.Run("Stat", func(t *testing.T) {
+		original := osStat
+		defer func() { osStat = original }()
+		osStat = func(name string) (os.FileInfo, error) {
+			return nil, errors.New("stat error")
+		}
+
+		_, err := filesystem.Stat("dummy")
+		if err == nil || err.Error() != "stat error" {
+			t.Errorf("expected stat error, got %v", err)
+		}
+	})
+}

--- a/fsx/relativefs.go
+++ b/fsx/relativefs.go
@@ -1,0 +1,210 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from: https://github.com/spf13/afero
+//
+
+package fsx
+
+import (
+	"io/fs"
+	"net"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// NewRelativeFS creates a new [FS] rooted at the given path
+// using the given child [FS] as the dependency.
+//
+// Any file name (after [filepath.Clean]) outside this base
+// path will be treated as a non-existing file.
+//
+// Any absolute file name will be treated as a non-existing file.
+//
+// We return [fs.ErrNotExist] in these cases.
+//
+// Note: This implementation cannot prevent symlink traversal
+// attacks. The caller must ensure the base directory does not
+// contain symlinks if this is a security requirement.
+func NewRelativeFS(dep FS, path string) *RelativeFS {
+	return &RelativeFS{basepath: path, dep: dep}
+}
+
+// RelativeFS is the [FS] type returned by [NewRelativeFS].
+//
+// The zero value IS NOT ready to use; construct using [NewRelativeFS].
+type RelativeFS struct {
+	// basepath is the base path.
+	basepath string
+
+	// dep is the dependency [FS].
+	dep FS
+}
+
+// Ensure [basePathFS] implements [FS].
+var _ FS = &RelativeFS{}
+
+// realPath returns the real path of a given file name or an error.
+func (rfs *RelativeFS) realPath(name string) (string, error) {
+	// 1. entirely reject absolute path names
+	if filepath.IsAbs(name) {
+		return "", fs.ErrNotExist
+	}
+
+	// 2. clean the path and make sure it is not outside the base path
+	bpath := filepath.Clean(rfs.basepath)
+	fullpath := filepath.Clean(filepath.Join(bpath, name))
+	if !strings.HasPrefix(fullpath, bpath) {
+		return name, fs.ErrNotExist
+	}
+	return fullpath, nil
+}
+
+// Chmod implements [FS].
+func (rfs *RelativeFS) Chmod(name string, mode fs.FileMode) error {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "chmod", Path: name, Err: err}
+	}
+	return rfs.dep.Chmod(name, mode)
+}
+
+// Chown implements [FS].
+func (rfs *RelativeFS) Chown(name string, uid, gid int) error {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "chown", Path: name, Err: err}
+	}
+	return rfs.dep.Chown(name, uid, gid)
+}
+
+// Chtimes implements [FS].
+func (rfs *RelativeFS) Chtimes(name string, atime, mtime time.Time) error {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "chtimes", Path: name, Err: err}
+	}
+	return rfs.dep.Chtimes(name, atime, mtime)
+}
+
+// Create implements [FS].
+func (rfs *RelativeFS) Create(name string) (File, error) {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "create", Path: name, Err: err}
+	}
+	return rfs.dep.Create(name)
+}
+
+// DialUnix implements [FS].
+func (rfs *RelativeFS) DialUnix(name string) (net.Conn, error) {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "dialunix", Path: name, Err: err}
+	}
+	return rfs.dep.DialUnix(name)
+}
+
+// ListenUnix implements [FS].
+func (rfs *RelativeFS) ListenUnix(name string) (net.Listener, error) {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "listenunix", Path: name, Err: err}
+	}
+	return rfs.dep.ListenUnix(name)
+}
+
+// Lstat implements [FS].
+func (rfs *RelativeFS) Lstat(name string) (fs.FileInfo, error) {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "lstat", Path: name, Err: err}
+	}
+	return rfs.dep.Lstat(name)
+}
+
+// Mkdir implements [FS].
+func (rfs *RelativeFS) Mkdir(name string, mode fs.FileMode) error {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	return rfs.dep.Mkdir(name, mode)
+}
+
+// MkdirAll implements [FS].
+func (rfs *RelativeFS) MkdirAll(name string, mode fs.FileMode) error {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	return rfs.dep.MkdirAll(name, mode)
+}
+
+// Open implements [FS].
+func (rfs *RelativeFS) Open(name string) (File, error) {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+	}
+	return rfs.dep.Open(name)
+}
+
+// OpenFile implements [FS].
+func (rfs *RelativeFS) OpenFile(name string, flag int, mode fs.FileMode) (File, error) {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "openfile", Path: name, Err: err}
+	}
+	return rfs.dep.OpenFile(name, flag, mode)
+}
+
+// ReadDir implements [FS].
+func (rfs *RelativeFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: err}
+	}
+	return rfs.dep.ReadDir(name)
+}
+
+// Remove implements [FS].
+func (rfs *RelativeFS) Remove(name string) error {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "remove", Path: name, Err: err}
+	}
+	return rfs.dep.Remove(name)
+}
+
+// RemoveAll implements [FS].
+func (rfs *RelativeFS) RemoveAll(name string) error {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "removeall", Path: name, Err: err}
+	}
+	return rfs.dep.RemoveAll(name)
+}
+
+// Rename implements [FS].
+func (rfs *RelativeFS) Rename(oldname, newname string) error {
+	oldname, err := rfs.realPath(oldname)
+	if err != nil {
+		return &fs.PathError{Op: "rename", Path: oldname, Err: err}
+	}
+	newname, err = rfs.realPath(newname)
+	if err != nil {
+		return &fs.PathError{Op: "rename", Path: newname, Err: err}
+	}
+	return rfs.dep.Rename(oldname, newname)
+}
+
+// Stat implements [FS].
+func (rfs *RelativeFS) Stat(name string) (fs.FileInfo, error) {
+	name, err := rfs.realPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
+	}
+	return rfs.dep.Stat(name)
+}

--- a/fsx/relativefs_test.go
+++ b/fsx/relativefs_test.go
@@ -1,0 +1,726 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package fsx_test
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/rbmk-project/common/fsx"
+	"github.com/rbmk-project/common/mocks"
+)
+
+func TestRelativeFS(t *testing.T) {
+	expected := errors.New("mocked error")
+
+	type testCase struct {
+		name     string
+		path     string
+		setup    func(*mocks.FsmodelFS)
+		testFunc func(*fsx.RelativeFS, string) error
+		want     error
+	}
+
+	// define a system dependent absolute path
+	var absolutePath string
+	switch runtime.GOOS {
+	case "windows":
+		absolutePath = "C:\\absolute\\path"
+	default:
+		absolutePath = "/absolute/path"
+	}
+
+	tests := map[string][]testCase{
+		"Chmod": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockChmod = func(name string, mode fs.FileMode) error {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Chmod(path, 0600)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Chmod(path, 0600)
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Chmod(path, 0600)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Chown": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockChown = func(name string, uid, gid int) error {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Chown(path, 1000, 1000)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Chown(path, 1000, 1000)
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Chown(path, 1000, 1000)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Chtimes": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockChtimes = func(name string, atime, mtime time.Time) error {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					now := time.Now()
+					return fs.Chtimes(path, now, now)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					now := time.Now()
+					return fs.Chtimes(path, now, now)
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					now := time.Now()
+					return fs.Chtimes(path, now, now)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Create": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockCreate = func(name string) (fsx.File, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Create(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Create(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Create(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"DialUnix": {
+			{
+				name: "RelativePathWithinBase",
+				path: "socket.sock",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockDialUnix = func(name string) (net.Conn, error) {
+						if name != "/base/socket.sock" {
+							t.Fatalf("expected path %q, got %q", "/base/socket.sock", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.DialUnix(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.DialUnix(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.DialUnix(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"ListenUnix": {
+			{
+				name: "RelativePathWithinBase",
+				path: "socket.sock",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockListenUnix = func(name string) (net.Listener, error) {
+						if name != "/base/socket.sock" {
+							t.Fatalf("expected path %q, got %q", "/base/socket.sock", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.ListenUnix(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.ListenUnix(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.ListenUnix(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Lstat": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockLstat = func(name string) (fs.FileInfo, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Lstat(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Lstat(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Lstat(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Mkdir": {
+			{
+				name: "RelativePathWithinBase",
+				path: "dir",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockMkdir = func(name string, perm fs.FileMode) error {
+						if name != "/base/dir" {
+							t.Fatalf("expected path %q, got %q", "/base/dir", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Mkdir(path, 0755)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Mkdir(path, 0755)
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Mkdir(path, 0755)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"MkdirAll": {
+			{
+				name: "RelativePathWithinBase",
+				path: "dir/subdir",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockMkdirAll = func(name string, perm fs.FileMode) error {
+						if name != "/base/dir/subdir" {
+							t.Fatalf("expected path %q, got %q", "/base/dir/subdir", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.MkdirAll(path, 0755)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.MkdirAll(path, 0755)
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.MkdirAll(path, 0755)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Open": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockOpen = func(name string) (fsx.File, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Open(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Open(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Open(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"OpenFile": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockOpenFile = func(name string, flag int, perm fs.FileMode) (fsx.File, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.OpenFile(path, fsx.O_CREATE|fsx.O_WRONLY, 0644)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.OpenFile(path, fsx.O_CREATE|fsx.O_WRONLY, 0644)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.OpenFile(path, fsx.O_CREATE|fsx.O_WRONLY, 0644)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"ReadDir": {
+			{
+				name: "RelativePathWithinBase",
+				path: "dir",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						if name != "/base/dir" {
+							t.Fatalf("expected path %q, got %q", "/base/dir", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.ReadDir(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.ReadDir(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.ReadDir(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Remove": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockRemove = func(name string) error {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Remove(path)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Remove(path)
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Remove(path)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"RemoveAll": {
+			{
+				name: "RelativePathWithinBase",
+				path: "dir",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockRemoveAll = func(name string) error {
+						if name != "/base/dir" {
+							t.Fatalf("expected path %q, got %q", "/base/dir", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.RemoveAll(path)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.RemoveAll(path)
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.RemoveAll(path)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Rename": {
+			{
+				name: "RelativePathWithinBase",
+				path: "old.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockRename = func(oldname, newname string) error {
+						if oldname != "/base/old.txt" || newname != "/base/new.txt" {
+							t.Fatalf("expected paths %q and %q, got %q and %q", "/base/old.txt", "/base/new.txt", oldname, newname)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Rename(path, "new.txt")
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePathFirst",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Rename(path, "new.txt")
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePathFirst",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Rename(path, "new.txt")
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "AbsolutePathSecond",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Rename("old.txt", path)
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePathSecond",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					return fs.Rename("old.txt", path)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Stat": {
+			{
+				name: "RelativePathWithinBase",
+				path: "file.txt",
+				setup: func(mockFS *mocks.FsmodelFS) {
+					mockFS.MockStat = func(name string) (fs.FileInfo, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Stat(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "AbsolutePath",
+				path:  filepath.FromSlash(absolutePath),
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Stat(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FsmodelFS) {},
+				testFunc: func(fs *fsx.RelativeFS, path string) error {
+					_, err := fs.Stat(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+	}
+
+	for groupName, group := range tests {
+		for _, tt := range group {
+			t.Run(groupName+": "+tt.name, func(t *testing.T) {
+				mockFS := &mocks.FsmodelFS{}
+				tt.setup(mockFS)
+				relativeFS := fsx.NewRelativeFS(mockFS, "/base")
+
+				err := tt.testFunc(relativeFS, tt.path)
+
+				if !errors.Is(err, tt.want) {
+					t.Errorf("got error %v, want %v", err, tt.want)
+				}
+			})
+		}
+	}
+}

--- a/fsx/relativefs_test.go
+++ b/fsx/relativefs_test.go
@@ -21,7 +21,7 @@ func TestRelativeFS(t *testing.T) {
 	type testCase struct {
 		name     string
 		path     string
-		setup    func(*mocks.FsmodelFS)
+		setup    func(*mocks.FS)
 		testFunc func(*fsx.RelativeFS, string) error
 		want     error
 	}
@@ -40,7 +40,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockChmod = func(name string, mode fs.FileMode) error {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -57,7 +57,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Chmod(path, 0600)
 				},
@@ -67,7 +67,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Chmod(path, 0600)
 				},
@@ -79,7 +79,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockChown = func(name string, uid, gid int) error {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -96,7 +96,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Chown(path, 1000, 1000)
 				},
@@ -106,7 +106,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Chown(path, 1000, 1000)
 				},
@@ -118,7 +118,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockChtimes = func(name string, atime, mtime time.Time) error {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -136,7 +136,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					now := time.Now()
 					return fs.Chtimes(path, now, now)
@@ -147,7 +147,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					now := time.Now()
 					return fs.Chtimes(path, now, now)
@@ -160,7 +160,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockCreate = func(name string) (fsx.File, error) {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -178,7 +178,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.Create(path)
 					return err
@@ -189,7 +189,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.Create(path)
 					return err
@@ -202,7 +202,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "socket.sock",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockDialUnix = func(name string) (net.Conn, error) {
 						if name != "/base/socket.sock" {
 							t.Fatalf("expected path %q, got %q", "/base/socket.sock", name)
@@ -220,7 +220,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.DialUnix(path)
 					return err
@@ -231,7 +231,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.DialUnix(path)
 					return err
@@ -244,7 +244,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "socket.sock",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockListenUnix = func(name string) (net.Listener, error) {
 						if name != "/base/socket.sock" {
 							t.Fatalf("expected path %q, got %q", "/base/socket.sock", name)
@@ -262,7 +262,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.ListenUnix(path)
 					return err
@@ -273,7 +273,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.ListenUnix(path)
 					return err
@@ -286,7 +286,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockLstat = func(name string) (fs.FileInfo, error) {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -304,7 +304,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.Lstat(path)
 					return err
@@ -315,7 +315,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.Lstat(path)
 					return err
@@ -328,7 +328,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "dir",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockMkdir = func(name string, perm fs.FileMode) error {
 						if name != "/base/dir" {
 							t.Fatalf("expected path %q, got %q", "/base/dir", name)
@@ -345,7 +345,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Mkdir(path, 0755)
 				},
@@ -355,7 +355,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Mkdir(path, 0755)
 				},
@@ -367,7 +367,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "dir/subdir",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockMkdirAll = func(name string, perm fs.FileMode) error {
 						if name != "/base/dir/subdir" {
 							t.Fatalf("expected path %q, got %q", "/base/dir/subdir", name)
@@ -384,7 +384,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.MkdirAll(path, 0755)
 				},
@@ -394,7 +394,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.MkdirAll(path, 0755)
 				},
@@ -406,7 +406,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockOpen = func(name string) (fsx.File, error) {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -424,7 +424,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.Open(path)
 					return err
@@ -435,7 +435,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.Open(path)
 					return err
@@ -448,7 +448,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockOpenFile = func(name string, flag int, perm fs.FileMode) (fsx.File, error) {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -466,7 +466,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.OpenFile(path, fsx.O_CREATE|fsx.O_WRONLY, 0644)
 					return err
@@ -477,7 +477,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.OpenFile(path, fsx.O_CREATE|fsx.O_WRONLY, 0644)
 					return err
@@ -490,7 +490,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "dir",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
 						if name != "/base/dir" {
 							t.Fatalf("expected path %q, got %q", "/base/dir", name)
@@ -508,7 +508,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.ReadDir(path)
 					return err
@@ -519,7 +519,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.ReadDir(path)
 					return err
@@ -532,7 +532,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockRemove = func(name string) error {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -549,7 +549,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Remove(path)
 				},
@@ -559,7 +559,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Remove(path)
 				},
@@ -571,7 +571,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "dir",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockRemoveAll = func(name string) error {
 						if name != "/base/dir" {
 							t.Fatalf("expected path %q, got %q", "/base/dir", name)
@@ -588,7 +588,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.RemoveAll(path)
 				},
@@ -598,7 +598,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.RemoveAll(path)
 				},
@@ -610,7 +610,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "old.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockRename = func(oldname, newname string) error {
 						if oldname != "/base/old.txt" || newname != "/base/new.txt" {
 							t.Fatalf("expected paths %q and %q, got %q and %q", "/base/old.txt", "/base/new.txt", oldname, newname)
@@ -627,7 +627,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePathFirst",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Rename(path, "new.txt")
 				},
@@ -637,7 +637,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePathFirst",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Rename(path, "new.txt")
 				},
@@ -647,7 +647,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePathSecond",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Rename("old.txt", path)
 				},
@@ -657,7 +657,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePathSecond",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					return fs.Rename("old.txt", path)
 				},
@@ -669,7 +669,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name: "RelativePathWithinBase",
 				path: "file.txt",
-				setup: func(mockFS *mocks.FsmodelFS) {
+				setup: func(mockFS *mocks.FS) {
 					mockFS.MockStat = func(name string) (fs.FileInfo, error) {
 						if name != "/base/file.txt" {
 							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
@@ -687,7 +687,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "AbsolutePath",
 				path:  filepath.FromSlash(absolutePath),
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.Stat(path)
 					return err
@@ -698,7 +698,7 @@ func TestRelativeFS(t *testing.T) {
 			{
 				name:  "OutsideBasePath",
 				path:  "../outside",
-				setup: func(mockFS *mocks.FsmodelFS) {},
+				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.RelativeFS, path string) error {
 					_, err := fs.Stat(path)
 					return err
@@ -711,7 +711,7 @@ func TestRelativeFS(t *testing.T) {
 	for groupName, group := range tests {
 		for _, tt := range group {
 			t.Run(groupName+": "+tt.name, func(t *testing.T) {
-				mockFS := &mocks.FsmodelFS{}
+				mockFS := &mocks.FS{}
 				tt.setup(mockFS)
 				relativeFS := fsx.NewRelativeFS(mockFS, "/base")
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.3
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/sys v0.27.0
+	golang.org/x/sys v0.28.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
-golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/fsmodel/fsmodel.go
+++ b/internal/fsmodel/fsmodel.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package fsmodel provides an abstract file system model.
+package fsmodel
+
+import (
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"time"
+)
+
+// Forward file system constants.
+const (
+	O_CREATE = os.O_CREATE
+	O_RDONLY = os.O_RDONLY
+	O_RDWR   = os.O_RDWR
+	O_TRUNC  = os.O_TRUNC
+	O_WRONLY = os.O_WRONLY
+)
+
+// File represents a file in the filesystem.
+//
+// We use a simplified view of the full interface implemented by
+// [os.File] to allow for easier mocking and testing.
+type File io.ReadWriteCloser
+
+// Ensure [*os.File] implements [File].
+var _ File = &os.File{}
+
+// FS is the filesystem interface.
+//
+// Any simulated or real filesystem should implement this interface.
+type FS interface {
+	// Chmod changes the mode of the named file to mode.
+	Chmod(name string, mode fs.FileMode) error
+
+	// Chown changes the uid and gid of the named file.
+	Chown(name string, uid, gid int) error
+
+	// Chtimes changes the access and modification times of the named file.
+	Chtimes(name string, atime time.Time, mtime time.Time) error
+
+	// Create creates a file in the filesystem, returning the file or an error.
+	Create(name string) (File, error)
+
+	// DialUnix connects to a Unix-domain socket using the given file name.
+	DialUnix(name string) (net.Conn, error)
+
+	// ListenUnix creates a listening Unix-domain socket using the given file name.
+	ListenUnix(name string) (net.Listener, error)
+
+	// Lstat is like Stat but does not follow symbolic links.
+	Lstat(name string) (fs.FileInfo, error)
+
+	// Mkdir creates a directory in the filesystem, possibly returning an error.
+	Mkdir(name string, perm fs.FileMode) error
+
+	// MkdirAll creates a directory path and all parents that does not exist yet.
+	MkdirAll(path string, perm fs.FileMode) error
+
+	// Open opens a file, returning it or an error, if any.
+	Open(name string) (File, error)
+
+	// OpenFile opens a file using the given flags and the given mode.
+	OpenFile(name string, flag int, perm fs.FileMode) (File, error)
+
+	// ReadDir reads and returns the content of a given directory.
+	ReadDir(dirname string) ([]fs.DirEntry, error)
+
+	// Remove removes a file identified by name, returning an error, if any.
+	Remove(name string) error
+
+	// RemoveAll removes a directory path and any children it contains. It
+	// does not fail if the path does not exist (returns nil).
+	RemoveAll(path string) error
+
+	// Rename renames a file.
+	Rename(oldname, newname string) error
+
+	// Stat returns a FileInfo describing the named file, or an error.
+	Stat(name string) (fs.FileInfo, error)
+}

--- a/mocks/fsmodel.go
+++ b/mocks/fsmodel.go
@@ -1,0 +1,173 @@
+package mocks
+
+import (
+	"io/fs"
+	"net"
+	"time"
+
+	"github.com/rbmk-project/common/internal/fsmodel"
+)
+
+// FsmodelFS implements [fsmodel.FS] for testing
+type FsmodelFS struct {
+	// MockChmod implements Chmod
+	MockChmod func(name string, mode fs.FileMode) error
+
+	// MockChown implements Chown
+	MockChown func(name string, uid, gid int) error
+
+	// MockChtimes implements Chtimes
+	MockChtimes func(name string, atime time.Time, mtime time.Time) error
+
+	// MockCreate implements Create
+	MockCreate func(name string) (fsmodel.File, error)
+
+	// MockDialUnix implements DialUnix
+	MockDialUnix func(name string) (net.Conn, error)
+
+	// MockListenUnix implements ListenUnix
+	MockListenUnix func(name string) (net.Listener, error)
+
+	// MockLstat implements Lstat
+	MockLstat func(name string) (fs.FileInfo, error)
+
+	// MockMkdir implements Mkdir
+	MockMkdir func(name string, perm fs.FileMode) error
+
+	// MockMkdirAll implements MkdirAll
+	MockMkdirAll func(path string, perm fs.FileMode) error
+
+	// MockOpen implements Open
+	MockOpen func(name string) (fsmodel.File, error)
+
+	// MockOpenFile implements OpenFile
+	MockOpenFile func(name string, flag int, perm fs.FileMode) (fsmodel.File, error)
+
+	// MockReadDir implements ReadDir
+	MockReadDir func(dirname string) ([]fs.DirEntry, error)
+
+	// MockRemove implements Remove
+	MockRemove func(name string) error
+
+	// MockRemoveAll implements RemoveAll
+	MockRemoveAll func(path string) error
+
+	// MockRename implements Rename
+	MockRename func(oldname, newname string) error
+
+	// MockStat implements Stat
+	MockStat func(name string) (fs.FileInfo, error)
+}
+
+// Ensure FS implements fsmodel.FS
+var _ fsmodel.FS = &FsmodelFS{}
+
+// Chmod calls MockChmod
+func (m *FsmodelFS) Chmod(name string, mode fs.FileMode) error {
+	return m.MockChmod(name, mode)
+}
+
+// Chown calls MockChown
+func (m *FsmodelFS) Chown(name string, uid, gid int) error {
+	return m.MockChown(name, uid, gid)
+}
+
+// Chtimes calls MockChtimes
+func (m *FsmodelFS) Chtimes(name string, atime, mtime time.Time) error {
+	return m.MockChtimes(name, atime, mtime)
+}
+
+// Create calls MockCreate
+func (m *FsmodelFS) Create(name string) (fsmodel.File, error) {
+	return m.MockCreate(name)
+}
+
+// DialUnix calls MockDialUnix
+func (m *FsmodelFS) DialUnix(name string) (net.Conn, error) {
+	return m.MockDialUnix(name)
+}
+
+// ListenUnix calls MockListenUnix
+func (m *FsmodelFS) ListenUnix(name string) (net.Listener, error) {
+	return m.MockListenUnix(name)
+}
+
+// Lstat calls MockLstat
+func (m *FsmodelFS) Lstat(name string) (fs.FileInfo, error) {
+	return m.MockLstat(name)
+}
+
+// Mkdir calls MockMkdir
+func (m *FsmodelFS) Mkdir(name string, perm fs.FileMode) error {
+	return m.MockMkdir(name, perm)
+}
+
+// MkdirAll calls MockMkdirAll
+func (m *FsmodelFS) MkdirAll(path string, perm fs.FileMode) error {
+	return m.MockMkdirAll(path, perm)
+}
+
+// Open calls MockOpen
+func (m *FsmodelFS) Open(name string) (fsmodel.File, error) {
+	return m.MockOpen(name)
+}
+
+// OpenFile calls MockOpenFile
+func (m *FsmodelFS) OpenFile(name string, flag int, perm fs.FileMode) (fsmodel.File, error) {
+	return m.MockOpenFile(name, flag, perm)
+}
+
+// ReadDir calls MockReadDir
+func (m *FsmodelFS) ReadDir(dirname string) ([]fs.DirEntry, error) {
+	return m.MockReadDir(dirname)
+}
+
+// Remove calls MockRemove
+func (m *FsmodelFS) Remove(name string) error {
+	return m.MockRemove(name)
+}
+
+// RemoveAll calls MockRemoveAll
+func (m *FsmodelFS) RemoveAll(path string) error {
+	return m.MockRemoveAll(path)
+}
+
+// Rename calls MockRename
+func (m *FsmodelFS) Rename(oldname, newname string) error {
+	return m.MockRename(oldname, newname)
+}
+
+// Stat calls MockStat
+func (m *FsmodelFS) Stat(name string) (fs.FileInfo, error) {
+	return m.MockStat(name)
+}
+
+// FsmodelFile implements [fsmodel.File] for testing
+type FsmodelFile struct {
+	// MockRead implements Read
+	MockRead func(b []byte) (int, error)
+
+	// MockWrite implements Write
+	MockWrite func(b []byte) (int, error)
+
+	// MockClose implements Close
+	MockClose func() error
+}
+
+// Ensure FsmodelFile implements [fsmodel.File].
+var _ fsmodel.File = &FsmodelFile{}
+
+// Read calls MockRead
+func (m *FsmodelFile) Read(b []byte) (int, error) {
+	return m.MockRead(b)
+}
+
+// Write calls MockWrite
+func (m *FsmodelFile) Write(b []byte) (int, error) {
+	return m.MockWrite(b)
+}
+
+// Close calls MockClose
+func (m *FsmodelFile) Close() error {
+	return m.MockClose()
+}

--- a/mocks/fsmodel.go
+++ b/mocks/fsmodel.go
@@ -8,8 +8,14 @@ import (
 	"github.com/rbmk-project/common/internal/fsmodel"
 )
 
-// FsmodelFS implements [fsmodel.FS] for testing
-type FsmodelFS struct {
+// FsmodelFS is an alias for [fsmodel.FS].
+type FsmodelFS = fsmodel.FS
+
+// FsmodelFile is an alias for [fsmodel.File].
+type FsmodelFile = fsmodel.File
+
+// FS implements [FsmodelFS] for testing
+type FS struct {
 	// MockChmod implements Chmod
 	MockChmod func(name string, mode fs.FileMode) error
 
@@ -20,7 +26,7 @@ type FsmodelFS struct {
 	MockChtimes func(name string, atime time.Time, mtime time.Time) error
 
 	// MockCreate implements Create
-	MockCreate func(name string) (fsmodel.File, error)
+	MockCreate func(name string) (FsmodelFile, error)
 
 	// MockDialUnix implements DialUnix
 	MockDialUnix func(name string) (net.Conn, error)
@@ -38,10 +44,10 @@ type FsmodelFS struct {
 	MockMkdirAll func(path string, perm fs.FileMode) error
 
 	// MockOpen implements Open
-	MockOpen func(name string) (fsmodel.File, error)
+	MockOpen func(name string) (FsmodelFile, error)
 
 	// MockOpenFile implements OpenFile
-	MockOpenFile func(name string, flag int, perm fs.FileMode) (fsmodel.File, error)
+	MockOpenFile func(name string, flag int, perm fs.FileMode) (FsmodelFile, error)
 
 	// MockReadDir implements ReadDir
 	MockReadDir func(dirname string) ([]fs.DirEntry, error)
@@ -59,91 +65,91 @@ type FsmodelFS struct {
 	MockStat func(name string) (fs.FileInfo, error)
 }
 
-// Ensure FS implements fsmodel.FS
-var _ fsmodel.FS = &FsmodelFS{}
+// Ensure [FS] implements [FsmodelFS]
+var _ FsmodelFS = &FS{}
 
 // Chmod calls MockChmod
-func (m *FsmodelFS) Chmod(name string, mode fs.FileMode) error {
+func (m *FS) Chmod(name string, mode fs.FileMode) error {
 	return m.MockChmod(name, mode)
 }
 
 // Chown calls MockChown
-func (m *FsmodelFS) Chown(name string, uid, gid int) error {
+func (m *FS) Chown(name string, uid, gid int) error {
 	return m.MockChown(name, uid, gid)
 }
 
 // Chtimes calls MockChtimes
-func (m *FsmodelFS) Chtimes(name string, atime, mtime time.Time) error {
+func (m *FS) Chtimes(name string, atime, mtime time.Time) error {
 	return m.MockChtimes(name, atime, mtime)
 }
 
 // Create calls MockCreate
-func (m *FsmodelFS) Create(name string) (fsmodel.File, error) {
+func (m *FS) Create(name string) (FsmodelFile, error) {
 	return m.MockCreate(name)
 }
 
 // DialUnix calls MockDialUnix
-func (m *FsmodelFS) DialUnix(name string) (net.Conn, error) {
+func (m *FS) DialUnix(name string) (net.Conn, error) {
 	return m.MockDialUnix(name)
 }
 
 // ListenUnix calls MockListenUnix
-func (m *FsmodelFS) ListenUnix(name string) (net.Listener, error) {
+func (m *FS) ListenUnix(name string) (net.Listener, error) {
 	return m.MockListenUnix(name)
 }
 
 // Lstat calls MockLstat
-func (m *FsmodelFS) Lstat(name string) (fs.FileInfo, error) {
+func (m *FS) Lstat(name string) (fs.FileInfo, error) {
 	return m.MockLstat(name)
 }
 
 // Mkdir calls MockMkdir
-func (m *FsmodelFS) Mkdir(name string, perm fs.FileMode) error {
+func (m *FS) Mkdir(name string, perm fs.FileMode) error {
 	return m.MockMkdir(name, perm)
 }
 
 // MkdirAll calls MockMkdirAll
-func (m *FsmodelFS) MkdirAll(path string, perm fs.FileMode) error {
+func (m *FS) MkdirAll(path string, perm fs.FileMode) error {
 	return m.MockMkdirAll(path, perm)
 }
 
 // Open calls MockOpen
-func (m *FsmodelFS) Open(name string) (fsmodel.File, error) {
+func (m *FS) Open(name string) (FsmodelFile, error) {
 	return m.MockOpen(name)
 }
 
 // OpenFile calls MockOpenFile
-func (m *FsmodelFS) OpenFile(name string, flag int, perm fs.FileMode) (fsmodel.File, error) {
+func (m *FS) OpenFile(name string, flag int, perm fs.FileMode) (FsmodelFile, error) {
 	return m.MockOpenFile(name, flag, perm)
 }
 
 // ReadDir calls MockReadDir
-func (m *FsmodelFS) ReadDir(dirname string) ([]fs.DirEntry, error) {
+func (m *FS) ReadDir(dirname string) ([]fs.DirEntry, error) {
 	return m.MockReadDir(dirname)
 }
 
 // Remove calls MockRemove
-func (m *FsmodelFS) Remove(name string) error {
+func (m *FS) Remove(name string) error {
 	return m.MockRemove(name)
 }
 
 // RemoveAll calls MockRemoveAll
-func (m *FsmodelFS) RemoveAll(path string) error {
+func (m *FS) RemoveAll(path string) error {
 	return m.MockRemoveAll(path)
 }
 
 // Rename calls MockRename
-func (m *FsmodelFS) Rename(oldname, newname string) error {
+func (m *FS) Rename(oldname, newname string) error {
 	return m.MockRename(oldname, newname)
 }
 
 // Stat calls MockStat
-func (m *FsmodelFS) Stat(name string) (fs.FileInfo, error) {
+func (m *FS) Stat(name string) (fs.FileInfo, error) {
 	return m.MockStat(name)
 }
 
-// FsmodelFile implements [fsmodel.File] for testing
-type FsmodelFile struct {
+// File implements [FsmodelFile] for testing
+type File struct {
 	// MockRead implements Read
 	MockRead func(b []byte) (int, error)
 
@@ -154,20 +160,20 @@ type FsmodelFile struct {
 	MockClose func() error
 }
 
-// Ensure FsmodelFile implements [fsmodel.File].
-var _ fsmodel.File = &FsmodelFile{}
+// Ensure [File] implements [FsmodelFile].
+var _ FsmodelFile = &File{}
 
 // Read calls MockRead
-func (m *FsmodelFile) Read(b []byte) (int, error) {
+func (m *File) Read(b []byte) (int, error) {
 	return m.MockRead(b)
 }
 
 // Write calls MockWrite
-func (m *FsmodelFile) Write(b []byte) (int, error) {
+func (m *File) Write(b []byte) (int, error) {
 	return m.MockWrite(b)
 }
 
 // Close calls MockClose
-func (m *FsmodelFile) Close() error {
+func (m *File) Close() error {
 	return m.MockClose()
 }

--- a/mocks/fsmodel_test.go
+++ b/mocks/fsmodel_test.go
@@ -1,0 +1,269 @@
+package mocks_test
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/rbmk-project/common/internal/fsmodel"
+	"github.com/rbmk-project/common/mocks"
+)
+
+func TestFsmodelFS(t *testing.T) {
+	t.Run("Chmod", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockChmod: func(name string, mode fs.FileMode) error {
+				return expected
+			},
+		}
+		err := fs.Chmod("test.txt", 0644)
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Chown", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockChown: func(name string, uid, gid int) error {
+				return expected
+			},
+		}
+		err := fs.Chown("test.txt", 1000, 1000)
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Chtimes", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockChtimes: func(name string, atime, mtime time.Time) error {
+				return expected
+			},
+		}
+		err := fs.Chtimes("test.txt", time.Now(), time.Now())
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockCreate: func(name string) (fsmodel.File, error) {
+				return nil, expected
+			},
+		}
+		_, err := fs.Create("test.txt")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("DialUnix", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockDialUnix: func(name string) (net.Conn, error) {
+				return nil, expected
+			},
+		}
+		_, err := fs.DialUnix("test.sock")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("ListenUnix", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockListenUnix: func(name string) (net.Listener, error) {
+				return nil, expected
+			},
+		}
+		_, err := fs.ListenUnix("test.sock")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Lstat", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockLstat: func(name string) (fs.FileInfo, error) {
+				return nil, expected
+			},
+		}
+		_, err := fs.Lstat("test.txt")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Mkdir", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockMkdir: func(name string, perm fs.FileMode) error {
+				return expected
+			},
+		}
+		err := fs.Mkdir("testdir", 0755)
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("MkdirAll", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockMkdirAll: func(path string, perm fs.FileMode) error {
+				return expected
+			},
+		}
+		err := fs.MkdirAll("testdir/subdir", 0755)
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockOpen: func(name string) (fsmodel.File, error) {
+				return nil, expected
+			},
+		}
+		_, err := fs.Open("test.txt")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("OpenFile", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockOpenFile: func(name string, flag int, perm fs.FileMode) (fsmodel.File, error) {
+				return nil, expected
+			},
+		}
+		_, err := fs.OpenFile("test.txt", fsmodel.O_CREATE|fsmodel.O_WRONLY, 0644)
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("ReadDir", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockReadDir: func(dirname string) ([]fs.DirEntry, error) {
+				return nil, expected
+			},
+		}
+		_, err := fs.ReadDir("testdir")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockRemove: func(name string) error {
+				return expected
+			},
+		}
+		err := fs.Remove("test.txt")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("RemoveAll", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockRemoveAll: func(path string) error {
+				return expected
+			},
+		}
+		err := fs.RemoveAll("testdir")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Rename", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockRename: func(oldname, newname string) error {
+				return expected
+			},
+		}
+		err := fs.Rename("old.txt", "new.txt")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+
+	t.Run("Stat", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		fs := &mocks.FsmodelFS{
+			MockStat: func(name string) (fs.FileInfo, error) {
+				return nil, expected
+			},
+		}
+		_, err := fs.Stat("test.txt")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+}
+
+func TestFsmodelFile(t *testing.T) {
+	t.Run("Read", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		file := &mocks.FsmodelFile{
+			MockRead: func(b []byte) (int, error) {
+				return 0, expected
+			},
+		}
+		count, err := file.Read(make([]byte, 128))
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+		if count != 0 {
+			t.Fatal("expected 0 bytes")
+		}
+	})
+
+	t.Run("Write", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		file := &mocks.FsmodelFile{
+			MockWrite: func(b []byte) (int, error) {
+				return 0, expected
+			},
+		}
+		count, err := file.Write(make([]byte, 128))
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+		if count != 0 {
+			t.Fatal("expected 0 bytes")
+		}
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		file := &mocks.FsmodelFile{
+			MockClose: func() error {
+				return expected
+			},
+		}
+		err := file.Close()
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+	})
+}

--- a/mocks/fsmodel_test.go
+++ b/mocks/fsmodel_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/rbmk-project/common/mocks"
 )
 
-func TestFsmodelFS(t *testing.T) {
+func TestFS(t *testing.T) {
 	t.Run("Chmod", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockChmod: func(name string, mode fs.FileMode) error {
 				return expected
 			},
@@ -27,7 +27,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Chown", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockChown: func(name string, uid, gid int) error {
 				return expected
 			},
@@ -40,7 +40,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Chtimes", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockChtimes: func(name string, atime, mtime time.Time) error {
 				return expected
 			},
@@ -53,7 +53,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockCreate: func(name string) (fsmodel.File, error) {
 				return nil, expected
 			},
@@ -66,7 +66,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("DialUnix", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockDialUnix: func(name string) (net.Conn, error) {
 				return nil, expected
 			},
@@ -79,7 +79,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("ListenUnix", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockListenUnix: func(name string) (net.Listener, error) {
 				return nil, expected
 			},
@@ -92,7 +92,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Lstat", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockLstat: func(name string) (fs.FileInfo, error) {
 				return nil, expected
 			},
@@ -105,7 +105,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Mkdir", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockMkdir: func(name string, perm fs.FileMode) error {
 				return expected
 			},
@@ -118,7 +118,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("MkdirAll", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockMkdirAll: func(path string, perm fs.FileMode) error {
 				return expected
 			},
@@ -131,7 +131,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Open", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockOpen: func(name string) (fsmodel.File, error) {
 				return nil, expected
 			},
@@ -144,7 +144,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("OpenFile", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockOpenFile: func(name string, flag int, perm fs.FileMode) (fsmodel.File, error) {
 				return nil, expected
 			},
@@ -157,7 +157,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("ReadDir", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockReadDir: func(dirname string) ([]fs.DirEntry, error) {
 				return nil, expected
 			},
@@ -170,7 +170,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Remove", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockRemove: func(name string) error {
 				return expected
 			},
@@ -183,7 +183,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("RemoveAll", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockRemoveAll: func(path string) error {
 				return expected
 			},
@@ -196,7 +196,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Rename", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockRename: func(oldname, newname string) error {
 				return expected
 			},
@@ -209,7 +209,7 @@ func TestFsmodelFS(t *testing.T) {
 
 	t.Run("Stat", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		fs := &mocks.FsmodelFS{
+		fs := &mocks.FS{
 			MockStat: func(name string) (fs.FileInfo, error) {
 				return nil, expected
 			},
@@ -221,10 +221,10 @@ func TestFsmodelFS(t *testing.T) {
 	})
 }
 
-func TestFsmodelFile(t *testing.T) {
+func TestFile(t *testing.T) {
 	t.Run("Read", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		file := &mocks.FsmodelFile{
+		file := &mocks.File{
 			MockRead: func(b []byte) (int, error) {
 				return 0, expected
 			},
@@ -240,7 +240,7 @@ func TestFsmodelFile(t *testing.T) {
 
 	t.Run("Write", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		file := &mocks.FsmodelFile{
+		file := &mocks.File{
 			MockWrite: func(b []byte) (int, error) {
 				return 0, expected
 			},
@@ -256,7 +256,7 @@ func TestFsmodelFile(t *testing.T) {
 
 	t.Run("Close", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		file := &mocks.FsmodelFile{
+		file := &mocks.File{
 			MockClose: func() error {
 				return expected
 			},


### PR DESCRIPTION
This abstraction is based on github.com/spf13/afero but adds specific changes that make the code suitable for rbmk.

We will use this new functionality for testing of the rbmk tool and possibly also to allow to virtualise the file system, a feature that may be useful for embedding rbmk.

This change also required to extend the mocks to mock the new filesystem types. The actual shared model between fsx and the mocks package is a private model in the internal folder. The fsx package exports all the private model definitions to fsx consumers.

While there upgrade dependencies.