### PR TITLE
feat(cliutils): add filesystem abstraction to Environment

### DIFF
--- a/cliutils/cliutils_test.go
+++ b/cliutils/cliutils_test.go
@@ -29,6 +29,7 @@ func (f fakecmd) Main(ctx context.Context, env cliutils.Environment, argv ...str
 
 func TestStandardEnvironment(t *testing.T) {
 	env := cliutils.StandardEnvironment{}
+	_ = env.FS() // unclear how to test this
 	if env.Stdin() != os.Stdin {
 		t.Fatal("expected os.Stdin")
 	}

--- a/cliutils/clutils.go
+++ b/cliutils/clutils.go
@@ -9,10 +9,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/rbmk-project/common/fsx"
 )
 
 // Environment is the environment for executing a [Command].
 type Environment interface {
+	// FS returns the virtual filesystem to use.
+	FS() fsx.FS
+
 	// Stdin returns the stdin reader to use.
 	Stdin() io.Reader
 
@@ -28,6 +33,11 @@ type StandardEnvironment struct{}
 
 // Ensure that [StandardEnvironment] implements [Environment].
 var _ Environment = StandardEnvironment{}
+
+// FS implements [Environment].
+func (se StandardEnvironment) FS() fsx.FS {
+	return fsx.OsFS{}
+}
 
 // Stdin implements [Environment].
 func (se StandardEnvironment) Stdin() io.Reader {


### PR DESCRIPTION
This commit adds the fsx.FS filesystem asbtraction to the Environment, which allows users of the cliutils package to virtualise the filesystem being used.

The default Environment uses the fsx.OsFS{} file system, which is equivalent to directly using the stdlib.