### PR TITLE
doc(ChdirFS.ListenUnix): explain max path limitations

### DIFF
--- a/fsx/chdirfs.go
+++ b/fsx/chdirfs.go
@@ -21,14 +21,6 @@ func NewChdirFS(dep FS, path string) *ChdirFS {
 
 // ChdirFS is the [FS] type returned by [NewChdirFS].
 //
-// Portability note: Unix domain sockets have path length limitations
-// ranging around ~100 chars (e.g., 108 on Linux, 104 on macOS) for
-// historical reasons (see, e.g., https://unix.stackexchange.com/q/367008).
-// When using [ChdirFS] with Unix domain sockets, therefore, it is
-// possible to get `EINVAL` errors in `bind`, which occurs when the
-// combined path is too long. If possible, consider using a relative
-// base path (if you know you'll never chdir elsewhere).
-//
 // The zero value IS NOT ready to use; construct using [NewChdirFS].
 type ChdirFS struct {
 	// basepath is the base path.
@@ -67,13 +59,15 @@ func (rfs *ChdirFS) Create(name string) (File, error) {
 }
 
 // DialUnix implements [FS].
+//
+// See also the limitations documented in the top-level package docs.
 func (rfs *ChdirFS) DialUnix(name string) (net.Conn, error) {
 	return rfs.dep.DialUnix(rfs.realPath(name))
 }
 
 // ListenUnix implements [FS].
 //
-// See also the limitations documented in the [ChdirFS] type.
+// See also the limitations documented in the top-level package docs.
 func (rfs *ChdirFS) ListenUnix(name string) (net.Listener, error) {
 	return rfs.dep.ListenUnix(rfs.realPath(name))
 }

--- a/fsx/chdirfs.go
+++ b/fsx/chdirfs.go
@@ -21,6 +21,14 @@ func NewChdirFS(dep FS, path string) *ChdirFS {
 
 // ChdirFS is the [FS] type returned by [NewChdirFS].
 //
+// Portability note: Unix domain sockets have path length limitations
+// ranging around ~100 chars (e.g., 108 on Linux, 104 on macOS) for
+// historical reasons (see, e.g., https://unix.stackexchange.com/q/367008).
+// When using [ChdirFS] with Unix domain sockets, therefore, it is
+// possible to get `EINVAL` errors in `bind`, which occurs when the
+// combined path is too long. If possible, consider using a relative
+// base path (if you know you'll never chdir elsewhere).
+//
 // The zero value IS NOT ready to use; construct using [NewChdirFS].
 type ChdirFS struct {
 	// basepath is the base path.
@@ -64,6 +72,8 @@ func (rfs *ChdirFS) DialUnix(name string) (net.Conn, error) {
 }
 
 // ListenUnix implements [FS].
+//
+// See also the limitations documented in the [ChdirFS] type.
 func (rfs *ChdirFS) ListenUnix(name string) (net.Listener, error) {
 	return rfs.dep.ListenUnix(rfs.realPath(name))
 }

--- a/fsx/containedfs.go
+++ b/fsx/containedfs.go
@@ -108,6 +108,8 @@ func (rfs *ContainedFS) Create(name string) (File, error) {
 }
 
 // DialUnix implements [FS].
+//
+// See also the limitations documented in the top-level package docs.
 func (rfs *ContainedFS) DialUnix(name string) (net.Conn, error) {
 	name, err := rfs.realPath(name)
 	if err != nil {
@@ -117,6 +119,8 @@ func (rfs *ContainedFS) DialUnix(name string) (net.Conn, error) {
 }
 
 // ListenUnix implements [FS].
+//
+// See also the limitations documented in the top-level package docs.
 func (rfs *ContainedFS) ListenUnix(name string) (net.Listener, error) {
 	name, err := rfs.realPath(name)
 	if err != nil {

--- a/fsx/fsx.go
+++ b/fsx/fsx.go
@@ -12,6 +12,16 @@ This package is derived from [afero].
 In addition to [afero], we also implement support for dialing
 and listening unix domain sockets, and for Lstat.
 
+# Unix Domain Sockets Portability Note
+
+Beware that Unix domain sockets have path length limitations ranging
+around ~100 chars (e.g., 108 on Linux, 104 on macOS) for historical
+reasons (see, e.g., https://unix.stackexchange.com/q/367008). When using
+Unix domain sockets, therefore, it is possible to get `EINVAL` errors
+in `bind` or `connect`, which occur when the combined path is too long. If
+possible, consider using a relative base path (if you know you'll never
+chdir elsewhere), or possibly use secure temporary directories.
+
 [afero]: https://github.com/spf13/afero
 */
 package fsx

--- a/fsx/osfs.go
+++ b/fsx/osfs.go
@@ -94,11 +94,15 @@ func (OsFS) Create(name string) (File, error) {
 }
 
 // DialUnix implements [FS].
+//
+// See also the limitations documented in the top-level package docs.
 func (OsFS) DialUnix(name string) (net.Conn, error) {
 	return netDialUnix("unix", nil, &net.UnixAddr{Name: name, Net: "unix"})
 }
 
 // ListenUnix implements [FS].
+//
+// See also the limitations documented in the top-level package docs.
 func (OsFS) ListenUnix(name string) (net.Listener, error) {
 	return netListenUnix("unix", &net.UnixAddr{Name: name, Net: "unix"})
 }


### PR DESCRIPTION
This commit adds documentation explaining EINVAL errors occurring in ChdirFS.ListenUnix when the base path is too long, adding references explaining the rational for this UNIX sockets limitation.

It also suggests a potential workaround, i.e., using relative paths, when you know your process is not going to chdir.

It also adds a cross-reference from ListenUnix method doc to the type documentation to make this limitation more discoverable.