### PR TITLE
refactor(fsx): introduce RealPathMapper, OverlayFS

### DIFF
--- a/fsx/chdirfs.go
+++ b/fsx/chdirfs.go
@@ -9,16 +9,16 @@ package fsx
 // NewChdirFS creates a new [FS] where each file name is
 // prefixed with the given directory path.
 //
-// Deprecated: use [NewOverlayFS] with [NewRelativeBaseDirPathMapper] instead.
+// Deprecated: use [NewOverlayFS] with [NewRelativeChdirPathMapper] instead.
 func NewChdirFS(dep FS, path string) *ChdirFS {
-	return &ChdirFS{NewOverlayFS(dep, NewRelativeBaseDirPathMapper(path))}
+	return &ChdirFS{NewOverlayFS(dep, NewRelativeChdirPathMapper(path))}
 }
 
 // ChdirFS is the [FS] type returned by [NewChdirFS].
 //
 // The zero value IS NOT ready to use; construct using [NewChdirFS].
 //
-// Deprecated: use [NewOverlayFS] with [NewRelativeBaseDirPathMapper] instead.
+// Deprecated: use [NewOverlayFS] with [NewRelativeChdirPathMapper] instead.
 type ChdirFS struct {
 	*OverlayFS
 }

--- a/fsx/chdirfs.go
+++ b/fsx/chdirfs.go
@@ -6,118 +6,19 @@
 
 package fsx
 
-import (
-	"io/fs"
-	"net"
-	"path/filepath"
-	"time"
-)
-
 // NewChdirFS creates a new [FS] where each file name is
 // prefixed with the given directory path.
+//
+// Deprecated: use [NewOverlayFS] with [NewRelativeBaseDirPathMapper] instead.
 func NewChdirFS(dep FS, path string) *ChdirFS {
-	return &ChdirFS{basepath: path, dep: dep}
+	return &ChdirFS{NewOverlayFS(dep, NewRelativeBaseDirPathMapper(path))}
 }
 
 // ChdirFS is the [FS] type returned by [NewChdirFS].
 //
 // The zero value IS NOT ready to use; construct using [NewChdirFS].
+//
+// Deprecated: use [NewOverlayFS] with [NewRelativeBaseDirPathMapper] instead.
 type ChdirFS struct {
-	// basepath is the base path.
-	basepath string
-
-	// dep is the dependency [FS].
-	dep FS
-}
-
-// Ensure [basePathFS] implements [FS].
-var _ FS = &ChdirFS{}
-
-// realPath returns the real path of a given file name or an error.
-func (rfs *ChdirFS) realPath(name string) string {
-	return filepath.Join(rfs.basepath, name)
-}
-
-// Chmod implements [FS].
-func (rfs *ChdirFS) Chmod(name string, mode fs.FileMode) error {
-	return rfs.dep.Chmod(rfs.realPath(name), mode)
-}
-
-// Chown implements [FS].
-func (rfs *ChdirFS) Chown(name string, uid, gid int) error {
-	return rfs.dep.Chown(rfs.realPath(name), uid, gid)
-}
-
-// Chtimes implements [FS].
-func (rfs *ChdirFS) Chtimes(name string, atime, mtime time.Time) error {
-	return rfs.dep.Chtimes(rfs.realPath(name), atime, mtime)
-}
-
-// Create implements [FS].
-func (rfs *ChdirFS) Create(name string) (File, error) {
-	return rfs.dep.Create(rfs.realPath(name))
-}
-
-// DialUnix implements [FS].
-//
-// See also the limitations documented in the top-level package docs.
-func (rfs *ChdirFS) DialUnix(name string) (net.Conn, error) {
-	return rfs.dep.DialUnix(rfs.realPath(name))
-}
-
-// ListenUnix implements [FS].
-//
-// See also the limitations documented in the top-level package docs.
-func (rfs *ChdirFS) ListenUnix(name string) (net.Listener, error) {
-	return rfs.dep.ListenUnix(rfs.realPath(name))
-}
-
-// Lstat implements [FS].
-func (rfs *ChdirFS) Lstat(name string) (fs.FileInfo, error) {
-	return rfs.dep.Lstat(rfs.realPath(name))
-}
-
-// Mkdir implements [FS].
-func (rfs *ChdirFS) Mkdir(name string, mode fs.FileMode) error {
-	return rfs.dep.Mkdir(rfs.realPath(name), mode)
-}
-
-// MkdirAll implements [FS].
-func (rfs *ChdirFS) MkdirAll(name string, mode fs.FileMode) error {
-	return rfs.dep.MkdirAll(rfs.realPath(name), mode)
-}
-
-// Open implements [FS].
-func (rfs *ChdirFS) Open(name string) (File, error) {
-	return rfs.dep.Open(rfs.realPath(name))
-}
-
-// OpenFile implements [FS].
-func (rfs *ChdirFS) OpenFile(name string, flag int, mode fs.FileMode) (File, error) {
-	return rfs.dep.OpenFile(rfs.realPath(name), flag, mode)
-}
-
-// ReadDir implements [FS].
-func (rfs *ChdirFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	return rfs.dep.ReadDir(rfs.realPath(name))
-}
-
-// Remove implements [FS].
-func (rfs *ChdirFS) Remove(name string) error {
-	return rfs.dep.Remove(rfs.realPath(name))
-}
-
-// RemoveAll implements [FS].
-func (rfs *ChdirFS) RemoveAll(name string) error {
-	return rfs.dep.RemoveAll(rfs.realPath(name))
-}
-
-// Rename implements [FS].
-func (rfs *ChdirFS) Rename(oldname, newname string) error {
-	return rfs.dep.Rename(rfs.realPath(oldname), rfs.realPath(newname))
-}
-
-// Stat implements [FS].
-func (rfs *ChdirFS) Stat(name string) (fs.FileInfo, error) {
-	return rfs.dep.Stat(rfs.realPath(name))
+	*OverlayFS
 }

--- a/fsx/containedfs.go
+++ b/fsx/containedfs.go
@@ -6,14 +6,6 @@
 
 package fsx
 
-import (
-	"io/fs"
-	"net"
-	"path/filepath"
-	"strings"
-	"time"
-)
-
 // NewRelativeFS is a deprecated alias for [NewContainedFS].
 //
 // Deprecated: use [NewContainedFS] instead.
@@ -37,188 +29,17 @@ type RelativeFS = ContainedFS
 // Note: This implementation cannot prevent symlink traversal
 // attacks. The caller must ensure the base directory does not
 // contain symlinks if this is a security requirement.
+//
+// Deprecated: use [NewOverlayFS] with [NewRelativeContainedDirPathMapper] instead.
 func NewContainedFS(dep FS, path string) *ContainedFS {
-	return &ContainedFS{basepath: path, dep: dep}
+	return &ContainedFS{NewOverlayFS(dep, NewRelativeContainedDirPathMapper(path))}
 }
 
 // ContainedFS is the [FS] type returned by [NewContainedFS].
 //
 // The zero value IS NOT ready to use; construct using [NewContainedFS].
+//
+// Deprecated: use [NewOverlayFS] with [NewRelativeContainedDirPathMapper] instead.
 type ContainedFS struct {
-	// basepath is the base path.
-	basepath string
-
-	// dep is the dependency [FS].
-	dep FS
-}
-
-// Ensure [basePathFS] implements [FS].
-var _ FS = &ContainedFS{}
-
-// realPath returns the real path of a given file name or an error.
-func (rfs *ContainedFS) realPath(name string) (string, error) {
-	// 1. entirely reject absolute path names
-	if filepath.IsAbs(name) {
-		return "", fs.ErrNotExist
-	}
-
-	// 2. clean the path and make sure it is not outside the base path
-	bpath := filepath.Clean(rfs.basepath)
-	fullpath := filepath.Clean(filepath.Join(bpath, name))
-	if !strings.HasPrefix(fullpath, bpath) {
-		return name, fs.ErrNotExist
-	}
-	return fullpath, nil
-}
-
-// Chmod implements [FS].
-func (rfs *ContainedFS) Chmod(name string, mode fs.FileMode) error {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return &fs.PathError{Op: "chmod", Path: name, Err: err}
-	}
-	return rfs.dep.Chmod(name, mode)
-}
-
-// Chown implements [FS].
-func (rfs *ContainedFS) Chown(name string, uid, gid int) error {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return &fs.PathError{Op: "chown", Path: name, Err: err}
-	}
-	return rfs.dep.Chown(name, uid, gid)
-}
-
-// Chtimes implements [FS].
-func (rfs *ContainedFS) Chtimes(name string, atime, mtime time.Time) error {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return &fs.PathError{Op: "chtimes", Path: name, Err: err}
-	}
-	return rfs.dep.Chtimes(name, atime, mtime)
-}
-
-// Create implements [FS].
-func (rfs *ContainedFS) Create(name string) (File, error) {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return nil, &fs.PathError{Op: "create", Path: name, Err: err}
-	}
-	return rfs.dep.Create(name)
-}
-
-// DialUnix implements [FS].
-//
-// See also the limitations documented in the top-level package docs.
-func (rfs *ContainedFS) DialUnix(name string) (net.Conn, error) {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return nil, &fs.PathError{Op: "dialunix", Path: name, Err: err}
-	}
-	return rfs.dep.DialUnix(name)
-}
-
-// ListenUnix implements [FS].
-//
-// See also the limitations documented in the top-level package docs.
-func (rfs *ContainedFS) ListenUnix(name string) (net.Listener, error) {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return nil, &fs.PathError{Op: "listenunix", Path: name, Err: err}
-	}
-	return rfs.dep.ListenUnix(name)
-}
-
-// Lstat implements [FS].
-func (rfs *ContainedFS) Lstat(name string) (fs.FileInfo, error) {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return nil, &fs.PathError{Op: "lstat", Path: name, Err: err}
-	}
-	return rfs.dep.Lstat(name)
-}
-
-// Mkdir implements [FS].
-func (rfs *ContainedFS) Mkdir(name string, mode fs.FileMode) error {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
-	}
-	return rfs.dep.Mkdir(name, mode)
-}
-
-// MkdirAll implements [FS].
-func (rfs *ContainedFS) MkdirAll(name string, mode fs.FileMode) error {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
-	}
-	return rfs.dep.MkdirAll(name, mode)
-}
-
-// Open implements [FS].
-func (rfs *ContainedFS) Open(name string) (File, error) {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
-	}
-	return rfs.dep.Open(name)
-}
-
-// OpenFile implements [FS].
-func (rfs *ContainedFS) OpenFile(name string, flag int, mode fs.FileMode) (File, error) {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return nil, &fs.PathError{Op: "openfile", Path: name, Err: err}
-	}
-	return rfs.dep.OpenFile(name, flag, mode)
-}
-
-// ReadDir implements [FS].
-func (rfs *ContainedFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return nil, &fs.PathError{Op: "readdir", Path: name, Err: err}
-	}
-	return rfs.dep.ReadDir(name)
-}
-
-// Remove implements [FS].
-func (rfs *ContainedFS) Remove(name string) error {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return &fs.PathError{Op: "remove", Path: name, Err: err}
-	}
-	return rfs.dep.Remove(name)
-}
-
-// RemoveAll implements [FS].
-func (rfs *ContainedFS) RemoveAll(name string) error {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return &fs.PathError{Op: "removeall", Path: name, Err: err}
-	}
-	return rfs.dep.RemoveAll(name)
-}
-
-// Rename implements [FS].
-func (rfs *ContainedFS) Rename(oldname, newname string) error {
-	oldname, err := rfs.realPath(oldname)
-	if err != nil {
-		return &fs.PathError{Op: "rename", Path: oldname, Err: err}
-	}
-	newname, err = rfs.realPath(newname)
-	if err != nil {
-		return &fs.PathError{Op: "rename", Path: newname, Err: err}
-	}
-	return rfs.dep.Rename(oldname, newname)
-}
-
-// Stat implements [FS].
-func (rfs *ContainedFS) Stat(name string) (fs.FileInfo, error) {
-	name, err := rfs.realPath(name)
-	if err != nil {
-		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
-	}
-	return rfs.dep.Stat(name)
+	*OverlayFS
 }

--- a/fsx/fsx.go
+++ b/fsx/fsx.go
@@ -44,7 +44,7 @@ const (
 	O_APPEND = fsmodel.O_APPEND
 )
 
-// IsNotExist combines the [os.ErrNotExist] check with
+// IsNotExist combines the [os.IsNotExist] check with
 // checking for the [fs.ErrNotExist] error.
 func IsNotExist(err error) bool {
 	return errors.Is(err, fs.ErrNotExist) || os.IsNotExist(err)

--- a/fsx/overlayfs.go
+++ b/fsx/overlayfs.go
@@ -1,0 +1,186 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from: https://github.com/spf13/afero
+//
+
+package fsx
+
+import (
+	"io/fs"
+	"net"
+	"time"
+)
+
+// OverlayFS overlays a path manipulation function implemented
+// by [RealPathMapper] on top of another [FS].
+//
+// The zero value is invalid. Construct using [NewOverlayFS].
+type OverlayFS struct {
+	// rpm is the real path mapper.
+	rpm RealPathMapper
+
+	// fs is the underlying [FS].
+	fs FS
+}
+
+// NewOverlayFS creates a new [FS] that uses [RealPathMapper] to
+// map virtual paths to real paths on top of the given [FS].
+func NewOverlayFS(fs FS, rpm RealPathMapper) *OverlayFS {
+	return &OverlayFS{rpm: rpm, fs: fs}
+}
+
+// Ensure [OverlayFS] implements [FS].
+var _ FS = &OverlayFS{}
+
+// Chmod implements [FS].
+func (rfs *OverlayFS) Chmod(name string, mode fs.FileMode) error {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "chmod", Path: name, Err: err}
+	}
+	return rfs.fs.Chmod(name, mode)
+}
+
+// Chown implements [FS].
+func (rfs *OverlayFS) Chown(name string, uid, gid int) error {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "chown", Path: name, Err: err}
+	}
+	return rfs.fs.Chown(name, uid, gid)
+}
+
+// Chtimes implements [FS].
+func (rfs *OverlayFS) Chtimes(name string, atime, mtime time.Time) error {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "chtimes", Path: name, Err: err}
+	}
+	return rfs.fs.Chtimes(name, atime, mtime)
+}
+
+// Create implements [FS].
+func (rfs *OverlayFS) Create(name string) (File, error) {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "create", Path: name, Err: err}
+	}
+	return rfs.fs.Create(name)
+}
+
+// DialUnix implements [FS].
+//
+// See also the limitations documented in the top-level package docs.
+func (rfs *OverlayFS) DialUnix(name string) (net.Conn, error) {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "dialunix", Path: name, Err: err}
+	}
+	return rfs.fs.DialUnix(name)
+}
+
+// ListenUnix implements [FS].
+//
+// See also the limitations documented in the top-level package docs.
+func (rfs *OverlayFS) ListenUnix(name string) (net.Listener, error) {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "listenunix", Path: name, Err: err}
+	}
+	return rfs.fs.ListenUnix(name)
+}
+
+// Lstat implements [FS].
+func (rfs *OverlayFS) Lstat(name string) (fs.FileInfo, error) {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "lstat", Path: name, Err: err}
+	}
+	return rfs.fs.Lstat(name)
+}
+
+// Mkdir implements [FS].
+func (rfs *OverlayFS) Mkdir(name string, mode fs.FileMode) error {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	return rfs.fs.Mkdir(name, mode)
+}
+
+// MkdirAll implements [FS].
+func (rfs *OverlayFS) MkdirAll(name string, mode fs.FileMode) error {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	return rfs.fs.MkdirAll(name, mode)
+}
+
+// Open implements [FS].
+func (rfs *OverlayFS) Open(name string) (File, error) {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+	}
+	return rfs.fs.Open(name)
+}
+
+// OpenFile implements [FS].
+func (rfs *OverlayFS) OpenFile(name string, flag int, mode fs.FileMode) (File, error) {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "openfile", Path: name, Err: err}
+	}
+	return rfs.fs.OpenFile(name, flag, mode)
+}
+
+// ReadDir implements [FS].
+func (rfs *OverlayFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: err}
+	}
+	return rfs.fs.ReadDir(name)
+}
+
+// Remove implements [FS].
+func (rfs *OverlayFS) Remove(name string) error {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "remove", Path: name, Err: err}
+	}
+	return rfs.fs.Remove(name)
+}
+
+// RemoveAll implements [FS].
+func (rfs *OverlayFS) RemoveAll(name string) error {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return &fs.PathError{Op: "removeall", Path: name, Err: err}
+	}
+	return rfs.fs.RemoveAll(name)
+}
+
+// Rename implements [FS].
+func (rfs *OverlayFS) Rename(oldname, newname string) error {
+	oldname, err := rfs.rpm.RealPath(oldname)
+	if err != nil {
+		return &fs.PathError{Op: "rename", Path: oldname, Err: err}
+	}
+	newname, err = rfs.rpm.RealPath(newname)
+	if err != nil {
+		return &fs.PathError{Op: "rename", Path: newname, Err: err}
+	}
+	return rfs.fs.Rename(oldname, newname)
+}
+
+// Stat implements [FS].
+func (rfs *OverlayFS) Stat(name string) (fs.FileInfo, error) {
+	name, err := rfs.rpm.RealPath(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
+	}
+	return rfs.fs.Stat(name)
+}

--- a/fsx/overlayfs_test.go
+++ b/fsx/overlayfs_test.go
@@ -74,7 +74,7 @@ func TestOverlayFS(t *testing.T) {
 			},
 
 			{
-				name:  "BasePath",
+				name:  "OutsideBase",
 				path:  "../outside",
 				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.OverlayFS, path string) error {
@@ -104,7 +104,7 @@ func TestOverlayFS(t *testing.T) {
 			},
 
 			{
-				name:  "BasePath",
+				name:  "OutsideBase",
 				path:  "../outside",
 				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.OverlayFS, path string) error {
@@ -197,7 +197,7 @@ func TestOverlayFS(t *testing.T) {
 			},
 
 			{
-				name:  "BasePath",
+				name:  "OutsideBase",
 				path:  "../outside",
 				setup: func(mockFS *mocks.FS) {},
 				testFunc: func(fs *fsx.OverlayFS, path string) error {

--- a/fsx/overlayfs_test.go
+++ b/fsx/overlayfs_test.go
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package fsx_test
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rbmk-project/common/fsx"
+	"github.com/rbmk-project/common/mocks"
+)
+
+func TestOverlayFS(t *testing.T) {
+	expected := errors.New("mocked error")
+
+	type testCase struct {
+		name     string
+		path     string
+		setup    func(*mocks.FS)
+		testFunc func(*fsx.OverlayFS, string) error
+		want     error
+	}
+
+	tests := map[string][]testCase{
+		"Chmod": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockChmod = func(name string, mode fs.FileMode) error {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Chmod(path, 0600)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Chmod(path, 0600)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Chown": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockChown = func(name string, uid, gid int) error {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Chown(path, 1000, 1000)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "BasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Chown(path, 1000, 1000)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Chtimes": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockChtimes = func(name string, atime, mtime time.Time) error {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					now := time.Now()
+					return fs.Chtimes(path, now, now)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "BasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					now := time.Now()
+					return fs.Chtimes(path, now, now)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Create": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockCreate = func(name string) (fsx.File, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.Create(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.Create(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"DialUnix": {
+			{
+				name: "WithinBase",
+				path: "/base/socket.sock",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockDialUnix = func(name string) (net.Conn, error) {
+						if name != "/base/socket.sock" {
+							t.Fatalf("expected path %q, got %q", "/base/socket.sock", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.DialUnix(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.DialUnix(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"ListenUnix": {
+			{
+				name: "WithinBase",
+				path: "/base/socket.sock",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockListenUnix = func(name string) (net.Listener, error) {
+						if name != "/base/socket.sock" {
+							t.Fatalf("expected path %q, got %q", "/base/socket.sock", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.ListenUnix(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "BasePath",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.ListenUnix(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Lstat": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockLstat = func(name string) (fs.FileInfo, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.Lstat(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.Lstat(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Mkdir": {
+			{
+				name: "WithinBase",
+				path: "/base/dir",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockMkdir = func(name string, perm fs.FileMode) error {
+						if name != "/base/dir" {
+							t.Fatalf("expected path %q, got %q", "/base/dir", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Mkdir(path, 0755)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Mkdir(path, 0755)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"MkdirAll": {
+			{
+				name: "WithinBase",
+				path: "/base/dir/subdir",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockMkdirAll = func(name string, perm fs.FileMode) error {
+						if name != "/base/dir/subdir" {
+							t.Fatalf("expected path %q, got %q", "/base/dir/subdir", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.MkdirAll(path, 0755)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.MkdirAll(path, 0755)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Open": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockOpen = func(name string) (fsx.File, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.Open(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.Open(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"OpenFile": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockOpenFile = func(name string, flag int, perm fs.FileMode) (fsx.File, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.OpenFile(path, fsx.O_CREATE|fsx.O_WRONLY, 0644)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.OpenFile(path, fsx.O_CREATE|fsx.O_WRONLY, 0644)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"ReadDir": {
+			{
+				name: "WithinBase",
+				path: "/base/dir",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						if name != "/base/dir" {
+							t.Fatalf("expected path %q, got %q", "/base/dir", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.ReadDir(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.ReadDir(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Remove": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockRemove = func(name string) error {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Remove(path)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Remove(path)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"RemoveAll": {
+			{
+				name: "WithinBase",
+				path: "/base/dir",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockRemoveAll = func(name string) error {
+						if name != "/base/dir" {
+							t.Fatalf("expected path %q, got %q", "/base/dir", name)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.RemoveAll(path)
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.RemoveAll(path)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Rename": {
+			{
+				name: "WithinBase",
+				path: "/base/old.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockRename = func(oldname, newname string) error {
+						if oldname != "/base/old.txt" || newname != "/base/new.txt" {
+							t.Fatalf("expected paths %q and %q, got %q and %q", "/base/old.txt", "/base/new.txt", oldname, newname)
+						}
+						return expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Rename(path, "/base/new.txt")
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBaseFirst",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Rename(path, "/base/new.txt")
+				},
+				want: fs.ErrNotExist,
+			},
+
+			{
+				name:  "OutsideBaseSecond",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					return fs.Rename("/base/old.txt", path)
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+
+		"Stat": {
+			{
+				name: "WithinBase",
+				path: "/base/file.txt",
+				setup: func(mockFS *mocks.FS) {
+					mockFS.MockStat = func(name string) (fs.FileInfo, error) {
+						if name != "/base/file.txt" {
+							t.Fatalf("expected path %q, got %q", "/base/file.txt", name)
+						}
+						return nil, expected
+					}
+				},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.Stat(path)
+					return err
+				},
+				want: expected,
+			},
+
+			{
+				name:  "OutsideBase",
+				path:  "../outside",
+				setup: func(mockFS *mocks.FS) {},
+				testFunc: func(fs *fsx.OverlayFS, path string) error {
+					_, err := fs.Stat(path)
+					return err
+				},
+				want: fs.ErrNotExist,
+			},
+		},
+	}
+
+	for groupName, group := range tests {
+		for _, tt := range group {
+			t.Run(groupName+": "+tt.name, func(t *testing.T) {
+				mockFS := &mocks.FS{}
+				tt.setup(mockFS)
+
+				// We create a real path mapper that rejects any path not
+				// starting with `/base` to test both the code path in which
+				// a path is accepted and the one in which it is rejected.
+				mapper := fsx.RealPathMapperFunc(func(path string) (string, error) {
+					if !strings.HasPrefix(path, "/base") {
+						return "", fs.ErrNotExist
+					}
+					return path, nil
+				})
+				relativeFS := fsx.NewOverlayFS(mockFS, mapper)
+
+				err := tt.testFunc(relativeFS, tt.path)
+
+				if !errors.Is(err, tt.want) {
+					t.Errorf("got error %v, want %v", err, tt.want)
+				}
+			})
+		}
+	}
+}

--- a/fsx/pathmappers.go
+++ b/fsx/pathmappers.go
@@ -1,0 +1,150 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from: https://github.com/spf13/afero
+//
+
+package fsx
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// RealPathMapper maps a virtual file name to its real path name.
+type RealPathMapper interface {
+	RealPath(virtualPath string) (realPath string, err error)
+}
+
+// RealPathMapperFunc is a function type that implements [RealPathMapper].
+type RealPathMapperFunc func(virtualPath string) (realPath string, err error)
+
+// Ensure [RealPathMapperFunc] implements [RealPathMapper].
+var _ RealPathMapper = RealPathMapperFunc(nil)
+
+// RealPath implements [RealPathMapper].
+func (fx RealPathMapperFunc) RealPath(virtualPath string) (realPath string, err error) {
+	return fx(virtualPath)
+}
+
+// Mockable [filepath.Abs] function for testing.
+var filepathAbs = filepath.Abs
+
+// BaseDirPathMapper is a [RealPathMapper] that prepends
+// a base directory to the virtual path.
+//
+// The zero value is invalid. Use [NewRelativeBaseDirPathMapper] or
+// [NewAbsoluteBaseDirPathMapper] to construct a new instance.
+type BaseDirPathMapper struct {
+	// baseDir is the base directory to prepend.
+	baseDir string
+}
+
+// NewAbsoluteBaseDirPathMapper converts the given directory
+// to an absolute path and, on success, returns a new
+// [*BaseDirPathMapper] instance. On failure, it returns and error.
+//
+// # Usage Considerations
+//
+// Use this constructor when you want your [*BaseDirPathMapper] to
+// be robust against concurrent invocations of [os.Chdir].
+func NewAbsoluteBaseDirPathMapper(baseDir string) (*BaseDirPathMapper, error) {
+	absBaseDir, err := filepathAbs(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	return &BaseDirPathMapper{baseDir: absBaseDir}, nil
+}
+
+// NewRelativeBaseDirPathMapper returns a new [*BaseDirPathMapper]
+// instance without bothering to check if the given directory
+// is relative or absolute.
+//
+// # Usage Considerations
+//
+// Use this constructor when you know your program is not going
+// to invoke [os.Chdir] so you can avoid building potentially long
+// paths that could break Unix domain sockets as documented in
+// the top-level package documentation.
+func NewRelativeBaseDirPathMapper(baseDir string) *BaseDirPathMapper {
+	return &BaseDirPathMapper{baseDir: baseDir}
+}
+
+// Ensure [BaseDirPathMapper] implements [RealPathMapper].
+var _ RealPathMapper = &BaseDirPathMapper{}
+
+// RealPath implements [RealPathMapper].
+func (b *BaseDirPathMapper) RealPath(virtualPath string) (realPath string, err error) {
+	return filepath.Join(b.baseDir, virtualPath), nil
+}
+
+// ContainedDirPathMapper is a [RealPathMapper] that prevents
+// accessing file names outside of a given base directory.
+//
+// Any file name (after [filepath.Clean]) outside this base
+// path will be treated as a non-existing file.
+//
+// Any absolute file name will be treated as a non-existing file.
+//
+// We return [fs.ErrNotExist] in these cases.
+//
+// Note: This implementation cannot prevent symlink traversal
+// attacks. The caller must ensure the base directory does not
+// contain symlinks if this is a security requirement.
+//
+// The zero value is invalid. Use [NewRelativeContainedDirPathMapper] or
+// [NewAbsoluteContainedDirPathMapper] to construct a new instance.
+type ContainedDirPathMapper struct {
+	// baseDir is the base directory to contain.
+	baseDir string
+}
+
+// NewAbsoluteContainedDirPathMapper converts the given directory
+// to an absolute path and, on success, returns a new [*ContainedDirPathMapper]
+// instance. On failure, it returns and error.
+//
+// # Usage Considerations
+//
+// Use this constructor when you want your [*ContainedDirPathMapper] to
+// be robust against concurrent invocations of [os.Chdir].
+func NewAbsoluteContainedDirPathMapper(baseDir string) (*ContainedDirPathMapper, error) {
+	absBaseDir, err := filepathAbs(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	return &ContainedDirPathMapper{baseDir: absBaseDir}, nil
+}
+
+// NewRelativeContainedDirPathMapper returns a new [*ContainedDirPathMapper]
+// instance without bothering to check if the given directory
+// is relative or absolute.
+//
+// # Usage Considerations
+//
+// Use this constructor when you know your program is not going
+// to invoke [os.Chdir] so you can avoid building potentially long
+// paths that could break Unix domain sockets as documented in
+// the top-level package documentation.
+func NewRelativeContainedDirPathMapper(baseDir string) *ContainedDirPathMapper {
+	return &ContainedDirPathMapper{baseDir: baseDir}
+}
+
+// Ensure [ContainedDirPathMapper] implements [RealPathMapper].
+var _ RealPathMapper = &ContainedDirPathMapper{}
+
+// RealPath implements [RealPathMapper].
+func (c *ContainedDirPathMapper) RealPath(virtualPath string) (realPath string, err error) {
+	// 1. entirely reject absolute path names
+	if filepath.IsAbs(virtualPath) {
+		return "", fs.ErrNotExist
+	}
+
+	// 2. clean the path and make sure it is not outside the base path
+	bpath := filepath.Clean(c.baseDir)
+	fullpath := filepath.Clean(filepath.Join(bpath, virtualPath))
+	if !strings.HasPrefix(fullpath, bpath) {
+		return "", fs.ErrNotExist
+	}
+	return fullpath, nil
+}

--- a/fsx/pathmappers.go
+++ b/fsx/pathmappers.go
@@ -31,33 +31,33 @@ func (fx RealPathMapperFunc) RealPath(virtualPath string) (realPath string, err 
 // Mockable [filepath.Abs] function for testing.
 var filepathAbs = filepath.Abs
 
-// BaseDirPathMapper is a [RealPathMapper] that prepends
+// ChdirPathMapper is a [RealPathMapper] that prepends
 // a base directory to the virtual path.
 //
-// The zero value is invalid. Use [NewRelativeBaseDirPathMapper] or
-// [NewAbsoluteBaseDirPathMapper] to construct a new instance.
-type BaseDirPathMapper struct {
+// The zero value is invalid. Use [NewRelativeChdirPathMapper] or
+// [NewAbsoluteChdirPathMapper] to construct a new instance.
+type ChdirPathMapper struct {
 	// baseDir is the base directory to prepend.
 	baseDir string
 }
 
-// NewAbsoluteBaseDirPathMapper converts the given directory
+// NewAbsoluteChdirPathMapper converts the given directory
 // to an absolute path and, on success, returns a new
-// [*BaseDirPathMapper] instance. On failure, it returns and error.
+// [*ChdirPathMapper] instance. On failure, it returns and error.
 //
 // # Usage Considerations
 //
-// Use this constructor when you want your [*BaseDirPathMapper] to
+// Use this constructor when you want your [*ChdirPathMapper] to
 // be robust against concurrent invocations of [os.Chdir].
-func NewAbsoluteBaseDirPathMapper(baseDir string) (*BaseDirPathMapper, error) {
+func NewAbsoluteChdirPathMapper(baseDir string) (*ChdirPathMapper, error) {
 	absBaseDir, err := filepathAbs(baseDir)
 	if err != nil {
 		return nil, err
 	}
-	return &BaseDirPathMapper{baseDir: absBaseDir}, nil
+	return &ChdirPathMapper{baseDir: absBaseDir}, nil
 }
 
-// NewRelativeBaseDirPathMapper returns a new [*BaseDirPathMapper]
+// NewRelativeChdirPathMapper returns a new [*ChdirPathMapper]
 // instance without bothering to check if the given directory
 // is relative or absolute.
 //
@@ -67,15 +67,15 @@ func NewAbsoluteBaseDirPathMapper(baseDir string) (*BaseDirPathMapper, error) {
 // to invoke [os.Chdir] so you can avoid building potentially long
 // paths that could break Unix domain sockets as documented in
 // the top-level package documentation.
-func NewRelativeBaseDirPathMapper(baseDir string) *BaseDirPathMapper {
-	return &BaseDirPathMapper{baseDir: baseDir}
+func NewRelativeChdirPathMapper(baseDir string) *ChdirPathMapper {
+	return &ChdirPathMapper{baseDir: baseDir}
 }
 
-// Ensure [BaseDirPathMapper] implements [RealPathMapper].
-var _ RealPathMapper = &BaseDirPathMapper{}
+// Ensure [ChdirPathMapper] implements [RealPathMapper].
+var _ RealPathMapper = &ChdirPathMapper{}
 
 // RealPath implements [RealPathMapper].
-func (b *BaseDirPathMapper) RealPath(virtualPath string) (realPath string, err error) {
+func (b *ChdirPathMapper) RealPath(virtualPath string) (realPath string, err error) {
 	return filepath.Join(b.baseDir, virtualPath), nil
 }
 

--- a/fsx/pathmappers_test.go
+++ b/fsx/pathmappers_test.go
@@ -46,16 +46,6 @@ func TestPathMappers(t *testing.T) {
 				},
 
 				{
-					name: "relative mapper with relative path",
-					construct: func(baseDir string) (RealPathMapper, error) {
-						return NewRelativeChdirPathMapper(baseDir), nil
-					},
-					baseDir: "testdata",
-					path:    "file.txt",
-					want:    filepath.Join("testdata", "file.txt"),
-				},
-
-				{
 					name: "absolute mapper with error",
 					construct: func(baseDir string) (RealPathMapper, error) {
 						return NewAbsoluteChdirPathMapper(baseDir)
@@ -65,6 +55,16 @@ func TestPathMappers(t *testing.T) {
 						return "", errMocked
 					},
 					wantError: errMocked,
+				},
+
+				{
+					name: "relative mapper with relative path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewRelativeChdirPathMapper(baseDir), nil
+					},
+					baseDir: "testdata",
+					path:    "file.txt",
+					want:    filepath.Join("testdata", "file.txt"),
 				},
 			},
 		},

--- a/fsx/pathmappers_test.go
+++ b/fsx/pathmappers_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package fsx
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPathMappers(t *testing.T) {
+	curdir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errMocked := errors.New("mocked error")
+
+	type testCase struct {
+		name      string
+		construct func(baseDir string) (RealPathMapper, error)
+		baseDir   string
+		path      string
+		mockAbs   func(string) (string, error)
+		want      string
+		wantError error
+	}
+
+	tests := []struct {
+		group string
+		cases []testCase
+	}{
+		{
+			group: "BaseDirPathMapper",
+			cases: []testCase{
+				{
+					name: "absolute mapper with relative path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewAbsoluteBaseDirPathMapper(baseDir)
+					},
+					baseDir: "testdata",
+					path:    "file.txt",
+					want:    filepath.Join(curdir, "testdata", "file.txt"),
+				},
+
+				{
+					name: "relative mapper with relative path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewRelativeBaseDirPathMapper(baseDir), nil
+					},
+					baseDir: "testdata",
+					path:    "file.txt",
+					want:    filepath.Join("testdata", "file.txt"),
+				},
+
+				{
+					name: "absolute mapper with error",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewAbsoluteBaseDirPathMapper(baseDir)
+					},
+					baseDir: "testdata",
+					mockAbs: func(path string) (string, error) {
+						return "", errMocked
+					},
+					wantError: errMocked,
+				},
+			},
+		},
+
+		{
+			group: "ContainedDirPathMapper",
+			cases: []testCase{
+				{
+					name: "absolute mapper with relative path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewAbsoluteContainedDirPathMapper(baseDir)
+					},
+					baseDir: "testdata",
+					path:    "file.txt",
+					want:    filepath.Join(curdir, "testdata", "file.txt"),
+				},
+
+				{
+					name: "absolute mapper with absolute path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewAbsoluteContainedDirPathMapper(baseDir)
+					},
+					baseDir:   "testdata",
+					path:      "/file.txt",
+					wantError: fs.ErrNotExist,
+				},
+
+				{
+					name: "absolute mapper with outside path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewAbsoluteContainedDirPathMapper(baseDir)
+					},
+					baseDir:   "testdata",
+					path:      "../file.txt",
+					wantError: fs.ErrNotExist,
+				},
+
+				{
+					name: "absolute mapper with error",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewAbsoluteContainedDirPathMapper(baseDir)
+					},
+					baseDir: "testdata",
+					mockAbs: func(path string) (string, error) {
+						return "", errMocked
+					},
+					wantError: errMocked,
+				},
+
+				{
+					name: "relative mapper with relative path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewRelativeContainedDirPathMapper(baseDir), nil
+					},
+					baseDir: "testdata",
+					path:    "file.txt",
+					want:    filepath.Join("testdata", "file.txt"),
+				},
+
+				{
+					name: "relative mapper with absolute path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewRelativeContainedDirPathMapper(baseDir), nil
+					},
+					baseDir:   "testdata",
+					path:      "/file.txt",
+					wantError: fs.ErrNotExist,
+				},
+
+				{
+					name: "relative mapper with outside path",
+					construct: func(baseDir string) (RealPathMapper, error) {
+						return NewRelativeContainedDirPathMapper(baseDir), nil
+					},
+					baseDir:   "testdata",
+					path:      "../file.txt",
+					wantError: fs.ErrNotExist,
+				},
+			},
+		},
+	}
+
+	for _, group := range tests {
+		t.Run(group.group, func(t *testing.T) {
+			for _, tt := range group.cases {
+				t.Run(tt.name, func(t *testing.T) {
+					if tt.mockAbs != nil {
+						saved := filepathAbs
+						filepathAbs = tt.mockAbs
+						defer func() { filepathAbs = saved }()
+					}
+
+					pmap, err := tt.construct(tt.baseDir)
+					if err != nil {
+						if !errors.Is(err, tt.wantError) {
+							t.Fatalf("unexpected construction error: got %v, want %v", err, tt.wantError)
+						}
+						return
+					}
+
+					got, err := pmap.RealPath(tt.path)
+					if !errors.Is(err, tt.wantError) {
+						t.Fatalf("unexpected error: got %v, want %v", err, tt.wantError)
+					}
+					if err == nil && got != tt.want {
+						t.Fatalf("got %q, want %q", got, tt.want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/fsx/pathmappers_test.go
+++ b/fsx/pathmappers_test.go
@@ -33,12 +33,12 @@ func TestPathMappers(t *testing.T) {
 		cases []testCase
 	}{
 		{
-			group: "BaseDirPathMapper",
+			group: "ChdirPathMapper",
 			cases: []testCase{
 				{
 					name: "absolute mapper with relative path",
 					construct: func(baseDir string) (RealPathMapper, error) {
-						return NewAbsoluteBaseDirPathMapper(baseDir)
+						return NewAbsoluteChdirPathMapper(baseDir)
 					},
 					baseDir: "testdata",
 					path:    "file.txt",
@@ -48,7 +48,7 @@ func TestPathMappers(t *testing.T) {
 				{
 					name: "relative mapper with relative path",
 					construct: func(baseDir string) (RealPathMapper, error) {
-						return NewRelativeBaseDirPathMapper(baseDir), nil
+						return NewRelativeChdirPathMapper(baseDir), nil
 					},
 					baseDir: "testdata",
 					path:    "file.txt",
@@ -58,7 +58,7 @@ func TestPathMappers(t *testing.T) {
 				{
 					name: "absolute mapper with error",
 					construct: func(baseDir string) (RealPathMapper, error) {
-						return NewAbsoluteBaseDirPathMapper(baseDir)
+						return NewAbsoluteChdirPathMapper(baseDir)
 					},
 					baseDir: "testdata",
 					mockAbs: func(path string) (string, error) {


### PR DESCRIPTION
This diff modifies how fsx works by introducing two new concepts:

1. the `OverlayFS`, which encapsulates the common logic used by `ChdirFS` and `ContainedFS` into a single codebase;

2. the `RealPathMapper`, which implements the path mapping policies used by `ChdirFS` and `ContainedFS`.

As a result, we can re-implement (and deprecate) `ChdirFS` and `ContainedFS` in light of these two new concepts. More in detail:

1. the `ChdirFS` path mapping policy is implemented by the new `ChdirPathMapper` type;

2. the `ContainedFS` by the new `ContainedDirPathMapper` type.

This change is important because it allows us to clarify the semantics of the base path used by a `RealPathMapper` in terms of whether such a base directory is relative or absolute.

For `ChdirPathMapper` and `ContainedDirPathMapper`, we define two constructors: one of them ensures the base directory is absolute, while the other one does not bother with that.

In turn, this is important because of Unix domain sockets, where there are limitations on the maximum socket name (i.e., file path) length. Thus, when using absolute paths in `rbmk sh`, it is easier to hit the limit and not being able to create the sockets.

This seems to suggest that we could switch to use relative paths *iff* we guarantee that `rbmk COMMAND` would not `chdir` for any `COMMAND` in `rbmk` except the `sh` command itself. However, baking this assumption in `fsx` would have been quite optimistic and backward, and made `fsx` itself harder to reuse.

On the contrary, by making the choice explicit in the constructors, we clearly document (with code that one needs to invoke) what are the expectations in terms of changing paths and, all in all, it seems explicit is generally better than implict.