### PR TITLE
refactor(fsx): rename {Chdir,PrefixDir}PathMapper

### DIFF
--- a/fsx/chdirfs.go
+++ b/fsx/chdirfs.go
@@ -9,16 +9,16 @@ package fsx
 // NewChdirFS creates a new [FS] where each file name is
 // prefixed with the given directory path.
 //
-// Deprecated: use [NewOverlayFS] with [NewRelativeChdirPathMapper] instead.
+// Deprecated: use [NewOverlayFS] with [NewRelativePrefixDirPathMapper] instead.
 func NewChdirFS(dep FS, path string) *ChdirFS {
-	return &ChdirFS{NewOverlayFS(dep, NewRelativeChdirPathMapper(path))}
+	return &ChdirFS{NewOverlayFS(dep, NewRelativePrefixDirPathMapper(path))}
 }
 
 // ChdirFS is the [FS] type returned by [NewChdirFS].
 //
 // The zero value IS NOT ready to use; construct using [NewChdirFS].
 //
-// Deprecated: use [NewOverlayFS] with [NewRelativeChdirPathMapper] instead.
+// Deprecated: use [NewOverlayFS] with [NewRelativePrefixDirPathMapper] instead.
 type ChdirFS struct {
 	*OverlayFS
 }

--- a/fsx/pathmappers.go
+++ b/fsx/pathmappers.go
@@ -31,33 +31,39 @@ func (fx RealPathMapperFunc) RealPath(virtualPath string) (realPath string, err 
 // Mockable [filepath.Abs] function for testing.
 var filepathAbs = filepath.Abs
 
-// ChdirPathMapper is a [RealPathMapper] that prepends
+// PrefixDirPathMapper is a [RealPathMapper] that prepends
 // a base directory to the virtual path.
 //
-// The zero value is invalid. Use [NewRelativeChdirPathMapper] or
-// [NewAbsoluteChdirPathMapper] to construct a new instance.
-type ChdirPathMapper struct {
+// The zero value is invalid. Use [NewRelativePrefixDirPathMapper] or
+// [NewAbsolutePrefixDirPathMapper] to construct a new instance.
+type PrefixDirPathMapper struct {
 	// baseDir is the base directory to prepend.
 	baseDir string
 }
 
-// NewAbsoluteChdirPathMapper converts the given directory
+// ChdirPathMapper is a deprecated alias for [PrefixDirPathMapper].
+type ChdirPathMapper = PrefixDirPathMapper
+
+// NewAbsolutePrefixDirPathMapper converts the given directory
 // to an absolute path and, on success, returns a new
-// [*ChdirPathMapper] instance. On failure, it returns and error.
+// [*PrefixDirPathMapper] instance. On failure, it returns and error.
 //
 // # Usage Considerations
 //
-// Use this constructor when you want your [*ChdirPathMapper] to
+// Use this constructor when you want your [*PrefixDirPathMapper] to
 // be robust against concurrent invocations of [os.Chdir].
-func NewAbsoluteChdirPathMapper(baseDir string) (*ChdirPathMapper, error) {
+func NewAbsolutePrefixDirPathMapper(baseDir string) (*PrefixDirPathMapper, error) {
 	absBaseDir, err := filepathAbs(baseDir)
 	if err != nil {
 		return nil, err
 	}
-	return &ChdirPathMapper{baseDir: absBaseDir}, nil
+	return &PrefixDirPathMapper{baseDir: absBaseDir}, nil
 }
 
-// NewRelativeChdirPathMapper returns a new [*ChdirPathMapper]
+// NewChdirPathMapper is a deprecated alias for [NewAbsolutePrefixDirPathMapper].
+var NewChdirPathMapper = NewAbsolutePrefixDirPathMapper
+
+// NewRelativePrefixDirPathMapper returns a new [*PrefixDirPathMapper]
 // instance without bothering to check if the given directory
 // is relative or absolute.
 //
@@ -67,15 +73,18 @@ func NewAbsoluteChdirPathMapper(baseDir string) (*ChdirPathMapper, error) {
 // to invoke [os.Chdir] so you can avoid building potentially long
 // paths that could break Unix domain sockets as documented in
 // the top-level package documentation.
-func NewRelativeChdirPathMapper(baseDir string) *ChdirPathMapper {
-	return &ChdirPathMapper{baseDir: baseDir}
+func NewRelativePrefixDirPathMapper(baseDir string) *PrefixDirPathMapper {
+	return &PrefixDirPathMapper{baseDir: baseDir}
 }
 
-// Ensure [ChdirPathMapper] implements [RealPathMapper].
-var _ RealPathMapper = &ChdirPathMapper{}
+// NewRelativeChdirPathMapper is a deprecated alias for [NewRelativePrefixDirPathMapper].
+var NewRelativeChdirPathMapper = NewRelativePrefixDirPathMapper
+
+// Ensure [PrefixDirPathMapper] implements [RealPathMapper].
+var _ RealPathMapper = &PrefixDirPathMapper{}
 
 // RealPath implements [RealPathMapper].
-func (b *ChdirPathMapper) RealPath(virtualPath string) (realPath string, err error) {
+func (b *PrefixDirPathMapper) RealPath(virtualPath string) (realPath string, err error) {
 	return filepath.Join(b.baseDir, virtualPath), nil
 }
 

--- a/fsx/pathmappers.go
+++ b/fsx/pathmappers.go
@@ -60,8 +60,8 @@ func NewAbsolutePrefixDirPathMapper(baseDir string) (*PrefixDirPathMapper, error
 	return &PrefixDirPathMapper{baseDir: absBaseDir}, nil
 }
 
-// NewChdirPathMapper is a deprecated alias for [NewAbsolutePrefixDirPathMapper].
-var NewChdirPathMapper = NewAbsolutePrefixDirPathMapper
+// NewAbsoluteChdirPathMapper is a deprecated alias for [NewAbsolutePrefixDirPathMapper].
+var NewAbsoluteChdirPathMapper = NewAbsolutePrefixDirPathMapper
 
 // NewRelativePrefixDirPathMapper returns a new [*PrefixDirPathMapper]
 // instance without bothering to check if the given directory

--- a/fsx/pathmappers_test.go
+++ b/fsx/pathmappers_test.go
@@ -33,12 +33,12 @@ func TestPathMappers(t *testing.T) {
 		cases []testCase
 	}{
 		{
-			group: "ChdirPathMapper",
+			group: "PrefixDirPathMapper",
 			cases: []testCase{
 				{
 					name: "absolute mapper with relative path",
 					construct: func(baseDir string) (RealPathMapper, error) {
-						return NewAbsoluteChdirPathMapper(baseDir)
+						return NewAbsolutePrefixDirPathMapper(baseDir)
 					},
 					baseDir: "testdata",
 					path:    "file.txt",
@@ -48,7 +48,7 @@ func TestPathMappers(t *testing.T) {
 				{
 					name: "absolute mapper with error",
 					construct: func(baseDir string) (RealPathMapper, error) {
-						return NewAbsoluteChdirPathMapper(baseDir)
+						return NewAbsolutePrefixDirPathMapper(baseDir)
 					},
 					baseDir: "testdata",
 					mockAbs: func(path string) (string, error) {
@@ -60,7 +60,7 @@ func TestPathMappers(t *testing.T) {
 				{
 					name: "relative mapper with relative path",
 					construct: func(baseDir string) (RealPathMapper, error) {
-						return NewRelativeChdirPathMapper(baseDir), nil
+						return NewRelativePrefixDirPathMapper(baseDir), nil
 					},
 					baseDir: "testdata",
 					path:    "file.txt",


### PR DESCRIPTION
The PrefixDir naming is more accurate because chdir implies there is an absolute base directory, while in this case we're just appending a relative or absolute prefix to it.

The previous names still exist but have been deprecated.