### PR TITLE
feat(closepool): implement CloserFunc

### DIFF
--- a/closepool/closepool.go
+++ b/closepool/closepool.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 )
 
-// CloserFunc allows to turn any function into an [io.Closer].
+// CloserFunc allows to turn a suitable function into an [io.Closer].
 type CloserFunc func() error
 
 // Ensure that [CloserFunc] implements [io.Closer].

--- a/closepool/closepool.go
+++ b/closepool/closepool.go
@@ -11,6 +11,17 @@ import (
 	"sync"
 )
 
+// CloserFunc allows to turn any function into an [io.Closer].
+type CloserFunc func() error
+
+// Ensure that [CloserFunc] implements [io.Closer].
+var _ io.Closer = CloserFunc(nil)
+
+// Close implements io.Closer.
+func (fx CloserFunc) Close() error {
+	return fx()
+}
+
 // Pool allows pooling a set of [io.Closer].
 //
 // The zero value is ready to use.

--- a/closepool/closepool_test.go
+++ b/closepool/closepool_test.go
@@ -26,9 +26,14 @@ func (m *mockCloser) Close() error {
 }
 
 func TestCloserFunc(t *testing.T) {
-	closer := &mockCloser{}
-	closepool.CloserFunc(closer.Close)()
-	if closer.closed.Load() <= 0 {
+	var closed bool
+	pool := &closepool.Pool{}
+	pool.Add(closepool.CloserFunc(func() error {
+		closed = true
+		return nil
+	}))
+	pool.Close()
+	if !closed {
 		t.Error("expected closer to be closed")
 	}
 }

--- a/closepool/closepool_test.go
+++ b/closepool/closepool_test.go
@@ -25,6 +25,14 @@ func (m *mockCloser) Close() error {
 	return m.err
 }
 
+func TestCloserFunc(t *testing.T) {
+	closer := &mockCloser{}
+	closepool.CloserFunc(closer.Close)()
+	if closer.closed.Load() <= 0 {
+		t.Error("expected closer to be closed")
+	}
+}
+
 func TestPool(t *testing.T) {
 	t.Run("successful close", func(t *testing.T) {
 		pool := closepool.Pool{}


### PR DESCRIPTION
This diff adds a CloserFunc type to closepool. We need this type to seamlessly adapt closeables that do not implement `io.Closer` to the `io.Closer` model. A concrete case where this would be needed is the `quic.Conn` type, which has a different close pattern.

We will likely need this in https://github.com/rbmk-project/dnscore/pull/18.