### PR TITLE
BREAKING CHANGE(mocks): make TLSConn usable

### DIFF
--- a/mocks/tlsconn.go
+++ b/mocks/tlsconn.go
@@ -2,7 +2,10 @@
 
 package mocks
 
-import "crypto/tls"
+import (
+	"context"
+	"crypto/tls"
+)
 
 // TLSConn is a mockable TLS connection.
 type TLSConn struct {
@@ -13,7 +16,7 @@ type TLSConn struct {
 	MockConnectionState func() tls.ConnectionState
 
 	// MockHandshakeContext is the function to call when HandshakeContext is called.
-	MockHandshakeContext func() error
+	MockHandshakeContext func(ctx context.Context) error
 }
 
 // ConnectionState calls MockConnectionState.
@@ -22,6 +25,6 @@ func (c *TLSConn) ConnectionState() tls.ConnectionState {
 }
 
 // HandshakeContext calls MockHandshakeContext.
-func (c *TLSConn) HandshakeContext() error {
-	return c.MockHandshakeContext()
+func (c *TLSConn) HandshakeContext(ctx context.Context) error {
+	return c.MockHandshakeContext(ctx)
 }

--- a/mocks/tlsconn.go
+++ b/mocks/tlsconn.go
@@ -9,8 +9,8 @@ import (
 
 // TLSConn is a mockable TLS connection.
 type TLSConn struct {
-	// We embed Conn to handle the net.Conn interface.
-	Conn
+	// We embed *Conn to handle the net.Conn interface.
+	*Conn
 
 	// MockConnectionState is the function to call when ConnectionState is called.
 	MockConnectionState func() tls.ConnectionState

--- a/mocks/tlsconn_test.go
+++ b/mocks/tlsconn_test.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"testing"
@@ -42,12 +43,12 @@ func TestTLSConn(t *testing.T) {
 	t.Run("HandshakeContext", func(t *testing.T) {
 		expected := errors.New("mocked handshake error")
 		conn := &TLSConn{
-			MockHandshakeContext: func() error {
+			MockHandshakeContext: func(ctx context.Context) error {
 				return expected
 			},
 		}
 
-		err := conn.HandshakeContext()
+		err := conn.HandshakeContext(context.Background())
 		if !errors.Is(err, expected) {
 			t.Fatal("not the error we expected")
 		}

--- a/mocks/tlsconn_test.go
+++ b/mocks/tlsconn_test.go
@@ -57,7 +57,7 @@ func TestTLSConn(t *testing.T) {
 	t.Run("Embedded Conn methods", func(t *testing.T) {
 		expected := errors.New("mocked read error")
 		conn := &TLSConn{
-			Conn: Conn{
+			Conn: &Conn{
 				MockRead: func(b []byte) (int, error) {
 					return 0, expected
 				},


### PR DESCRIPTION
I missed that `HandshakeContext` actually needs a context argument 🤦. Additionally, it seems more ergonomic to use a pointer embedding for `Conn` since that leads to less toil when writing unit tests.