### PR TITLE
fix(go.yml): use `-short` when measuring coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
           go-version: "1.24"
 
       - name: Measure Coverage
-        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+        run: go test -short -race -covermode=atomic -coverprofile=coverage.out ./...
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
We're not interested to measure integration tests' coverage.